### PR TITLE
fix(cmake): Not working on mac platform

### DIFF
--- a/Geode.cmake
+++ b/Geode.cmake
@@ -16,9 +16,6 @@ cmake_minimum_required(VERSION 3.13.4)
 
 set(GEODE_SDK_PATH ${CMAKE_CURRENT_LIST_DIR})
 
-set(CMAKE_APPLE_SILICON_PROCESSOR x86_64)
-set(CMAKE_OSX_ARCHITECTURES x86_64)
-
 include(CMakeParseArguments)
 include(${GEODE_SDK_PATH}/cmake/GeodeFile.cmake)
 

--- a/cmake/MacOS.cmake
+++ b/cmake/MacOS.cmake
@@ -1,8 +1,9 @@
 add_definitions(-DCC_TARGET_OS_MAC)
 set(CMAKE_SYSTEM_NAME MacOS)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fms-extensions -Wno-deprecated -Wno-ignored-attributes -arch x86_64 -O2 -Os -fdata-sections -ffunction-sections")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fms-extensions -Wno-deprecated -Wno-ignored-attributes -O2 -Os -fdata-sections -ffunction-sections")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -dead_strip")
+set(CMAKE_OSX_ARCHITECTURES x86_64)
 
 include_directories(
 	${GEODE_SDK_PATH}/include/cocos/cocos2dx/platform/mac


### PR DESCRIPTION
This fix the problem of mod not compiling on mac m1,
Although there's one thing to note,

If you have the following structure
```
root
|- CMakeLists.txt
|- sub-1
    |- CMakeLists.txt
|- sub-2
    |- CMakeLists.txt
```

It's advised to put this in the `root`'s CMakeLists.txt
```cmake
find_path(GEODE_SDK_PATH
	NAMES Geode.cmake
	PATHS $ENV{GEODE_SUITE}/sdk /Users/Shared/Geode/suite/sdk /usr/local/geode/sdk
	DOC "Geode SDK path."
	REQUIRED
)
include(${GEODE_SDK_PATH}/Geode.cmake)
```

If you decided to put it in both `sub-1` and `sub-2` CMakeLists.txt, It will cause the `sub-1` to compile as arm64 and other subdirectory as x86_64 (Don't ask me why this happened, i don't know and this is weird)