### PR TITLE
Let libcurl use the system's native CA alongside our bundle

### DIFF
--- a/loader/src/utils/web.cpp
+++ b/loader/src/utils/web.cpp
@@ -343,6 +343,8 @@ WebTask WebRequest::send(std::string_view method, std::string_view url) {
             caBundleBlob.len = impl->m_CABundleContent.size();
             caBundleBlob.flags = CURL_BLOB_COPY;
             curl_easy_setopt(curl, CURLOPT_CAINFO_BLOB, &caBundleBlob);
+            // Also add the native CA, for good measure
+            curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
         }
 
         // Transfer body


### PR DESCRIPTION
This might be a possible fix for the people that keep getting the `curl failed: SSL peer certificate or SSH remote key was not ok` error.