### PR TITLE
Fix a crash when updating layouts with a childless node.

### DIFF
--- a/loader/src/hooks/GeodeNodeMetadata.cpp
+++ b/loader/src/hooks/GeodeNodeMetadata.cpp
@@ -357,7 +357,7 @@ LayoutOptions* CCNode::getLayoutOptions() {
 }
 
 void CCNode::updateLayout(bool updateChildOrder) {
-    if (updateChildOrder) {
+    if (updateChildOrder && m_pChildren) {
         this->sortAllChildren();
     }
     if (auto layout = GeodeNodeMetadata::set(this)->m_layout.data()) {


### PR DESCRIPTION
Cocos does not check m_pChildren in sortAllChildren like it should, so if the CCArray is not allocated yet, updateLayout will crash the game. 