### PR TITLE
use fast_float library for float & integer parsing

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -287,10 +287,11 @@ if (NOT GEODE_BUILDING_DOCS)
 	set(SIMDUTF_TESTS OFF)
 	set(SIMDUTF_TOOLS OFF)
 	CPMAddPackage("gh:simdutf/simdutf#v6.5.0")
+	CPMAddPackage("gh:fastfloat/fast_float#v8.1.0")
 
 	target_include_directories(${PROJECT_NAME} PRIVATE ${md4c_SOURCE_DIR}/src)
 
-	target_link_libraries(${PROJECT_NAME} md4c minizip date simdutf)
+	target_link_libraries(${PROJECT_NAME} md4c minizip date simdutf fast_float)
 endif()
 
 target_link_libraries(${PROJECT_NAME} TulipHook geode-sdk mat-json-impl)

--- a/loader/src/utils/general.cpp
+++ b/loader/src/utils/general.cpp
@@ -1,4 +1,7 @@
 #include <Geode/utils/general.hpp>
+#include <fast_float/fast_float.h>
+
+using namespace geode::prelude;
 
 #ifndef GEODE_IS_MACOS
 // feel free to properly implement this for other platforms
@@ -6,3 +9,50 @@ float geode::utils::getDisplayFactor() {
     return 1.0f;
 }
 #endif
+
+template <typename T>
+static Result<T> toParseResult(T* value, fast_float::from_chars_result res, std::string_view str) {
+    auto [ptr, ec] = res;
+    if (ec == std::errc()) return Ok(*value);
+    else if (ptr != str.data() + str.size()) return Err("String contains trailing extra data");
+    else if (ec == std::errc::invalid_argument) return Err("String is not a number");
+    else if (ec == std::errc::result_out_of_range) return Err("Number is out of range for target type");
+    else return Err("Unknown error");
+}
+
+template <typename T>
+static Result<T> parseFloat(std::string_view str) {
+    T result;
+    auto res = fast_float::from_chars(str.data(), str.data() + str.size(), result);
+    return toParseResult(&result, res, str);
+}
+
+template <typename T>
+static Result<T> parseInt(std::string_view str, int base = 10) {
+    T result;
+    auto res = fast_float::from_chars(str.data(), str.data() + str.size(), result, base);
+    return toParseResult(&result, res, str);
+}
+
+Result<float> geode::utils::_detail::floatFromString(std::string_view str) {
+    return parseFloat<float>(str);
+}
+
+Result<double> geode::utils::_detail::doubleFromString(std::string_view str) {
+    return parseFloat<double>(str);
+}
+
+Result<long double> geode::utils::_detail::longDoubleFromString(std::string_view str) {
+    // ld not supported by fast float
+    return parseFloat<double>(str).map([](double val) {
+        return static_cast<long double>(val);
+    });
+}
+
+Result<uint64_t> geode::utils::_detail::uint64FromString(std::string_view str, int base) {
+    return parseInt<uint64_t>(str, base);
+}
+
+Result<int64_t> geode::utils::_detail::int64FromString(std::string_view str, int base) {
+    return parseInt<int64_t>(str, base);
+}


### PR DESCRIPTION
This changes the `numFromString` function to use a consistent method of parsing integers and floating point values, specifically the [fast_float](https://github.com/fastfloat/fast_float) library. Advantages of this change include:

* No more UB if the passed string is not null terminated (previous version passed sv.data() to std::strtof and friends even though that's very unsafe)
* Much faster, locale independent number parsing 
* Cleaner code in general (imo)