### PR TITLE
Add fix for scissor inside a render texture

### DIFF
--- a/loader/src/hooks/CCRenderTextureScissorFix.cpp
+++ b/loader/src/hooks/CCRenderTextureScissorFix.cpp
@@ -3,10 +3,8 @@
 
 using namespace geode::prelude;
 
-class $modify (CCEGLView)
-{
-    virtual void setScissorInPoints(float x, float y, float w, float h)
-    {
+class $modify (CCEGLView) {
+    virtual void setScissorInPoints(float x, float y, float w, float h) {
         GLint viewport[4];
         glGetIntegerv(GL_VIEWPORT, viewport);
 


### PR DESCRIPTION
this has to be a hook in geode, because if multiple mods do this hook then the fix breaks.