### PR TITLE
Fix geode::ScrollLayer for good

### DIFF
--- a/loader/src/ui/nodes/ScrollLayer.cpp
+++ b/loader/src/ui/nodes/ScrollLayer.cpp
@@ -29,12 +29,20 @@ public:
 GenericContentLayer::Impl::Impl(GenericContentLayer* self) : m_self(self) {}
 
 void GenericContentLayer::Impl::setPosition(CCPoint const& pos) {
+    auto parent = m_self->getParent();
+
+    if (parent && parent->getContentHeight() > m_self->getScaledContentHeight()) {
+        auto y = parent->getContentHeight() - m_self->getScaledContentHeight();
+        m_self->CCLayerColor::setPosition({pos.x, y});
+    }
+    else {
+        m_self->CCLayerColor::setPosition(pos);
+    }
+
     // CCContentLayer expect its children to
     // all be TableViewCells
-    m_self->CCLayerColor::setPosition(pos);
-
     CCSize scrollLayerSize{};
-    if (auto parent = m_self->getParent()) {
+    if (parent) {
         scrollLayerSize = parent->getContentSize();
     }
 


### PR DESCRIPTION
Adds a simple size check when changing the content layer's position, and adjust accordingly.