### PR TITLE
Improve version fetching with fallback to GitHub API

### DIFF
--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -195,9 +195,9 @@ if [ -z "$TAG" ]; then
     echo "Geode Index failed, checking GitHub releases..."
     GITHUB_JSON="$(curl -s 'https://api.github.com/repos/geode-sdk/geode/releases?per_page=1')"
     if [ -x "$(command -v jq)" ]; then
-        TAG="$(echo "$GITHUB_JSON" | jq -r '.[0].tag_name' 2>/dev/null)"
+        TAG="$(echo -E "$GITHUB_JSON" | jq -r '.[0].tag_name' 2>/dev/null)"
     else
-        TAG="$(echo "$GITHUB_JSON" | $py_cmd -c 'import json,sys; print(json.load(sys.stdin)[0]["tag_name"])' 2>/dev/null)"
+        TAG="$(echo -E "$GITHUB_JSON" | $py_cmd -c 'import json,sys; print(json.load(sys.stdin)[0]["tag_name"])' 2>/dev/null)"
     fi
 fi
 


### PR DESCRIPTION
Updated version retrieval logic to check GitHub releases if Geode Index fails.

> [!NOTE]
> This change fixes the bug when installing geode on Linux.
> Version: Geode v5.0.0-beta.2

Screenshot
<img width="803" height="386" alt="image" src="https://github.com/user-attachments/assets/1a061ce2-2f87-4a94-ba1f-cb1607e9a1bb" />
