### PR TITLE
Fix unfriendly keybind modifiers

### DIFF
--- a/loader/src/loader/LoaderImpl.hpp
+++ b/loader/src/loader/LoaderImpl.hpp
@@ -161,6 +161,7 @@ namespace geode {
         std::optional<std::string> getBinaryPath() const;
 
         std::unordered_map<Keybind, std::vector<std::shared_ptr<KeybindSettingV3>>> m_keybindSettings;
+        std::unordered_map<KeybindSettingV3*, Keybind> m_activeKeybinds;
         void onKeybindSettingChanged(std::shared_ptr<KeybindSettingV3> setting, std::vector<Keybind> const& keybinds);
     };
 


### PR DESCRIPTION
- store held down keybinds in unordered map
- release event will ignore modifiers if keybind was in map

Fixes:
- Releasing a modifier before the keybind key doesnt fire release event
- Setting the keybind key to only a modifier key will not fire release event
- Changing a keybind while holding the previous one down will not fire release event