### PR TITLE
Add geode::Button, a CCMenuItem(SpriteExtra) alternative

### DIFF
--- a/loader/include/Geode/ui/Button.hpp
+++ b/loader/include/Geode/ui/Button.hpp
@@ -1,0 +1,234 @@
+#pragma once
+
+#include <Geode/utils/ZStringView.hpp>
+#include <cocos2d.h>
+
+namespace geode {
+    class GEODE_DLL Button : public cocos2d::CCNodeRGBA, public cocos2d::CCTouchDelegate {
+    public:
+        using ButtonCallback = geode::Function<void(Button* sender)>;
+
+        enum class AnimationType {
+            // No animations at all
+            None,
+            // Uses custom animations
+            Custom,
+            // Scales the button by a multiplier
+            Scale,
+            // Moves the button by an offset
+            Move
+        };
+
+        /**
+         * Create a Button with no nodes on it
+         * You will need to add a child yourself and position accordingly.
+         * @param activateCallback The callback for when the button is activated
+         */
+        static Button* create(ButtonCallback activateCallback = nullptr);
+
+        /**
+         * Create a Button with a nodes on it.
+         * The node will be automatically positioned in the center.
+         * @param node The node that will show on the button.
+         * @param activateCallback The callback for when the button is activated
+         */
+        static Button* createWithNode(cocos2d::CCNode* node, ButtonCallback activateCallback = nullptr);
+
+        /**
+         * Create a Button with a sprite by file name
+         * @param fileName The file name of the sprite (not in a spritesheet)
+         * @param activateCallback The callback for when the button is activated
+         */
+        static Button* createWithSprite(geode::ZStringView fileName, ButtonCallback activateCallback = nullptr);
+
+        /**
+         * Create a Button with a sprite by frame name
+         * @param fileName The frame name of the sprite (in a spritesheet)
+         * @param activateCallback The callback for when the button is activated
+         */
+        static Button* createWithSpriteFrameName(geode::ZStringView frameName, ButtonCallback activateCallback = nullptr);
+
+        /**
+         * Create a Button with a label
+         * @param text The text shown on the label
+         * @param font The font of the label
+         * @param activateCallback The callback for when the button is activated
+         */
+        static Button* createWithLabel(geode::ZStringView text, geode::ZStringView font, ButtonCallback activateCallback = nullptr);
+
+        /**
+         * Get the Display Node, which was created or passed in on button creation
+         * Will be nullptr if you use the empty create method
+         */
+        cocos2d::CCNode* getDisplayNode();
+
+        /**
+         * Set an animation type, which dictates how the button moves or scales
+         * or if it even has an animation at all
+         */
+        void setAnimationType(AnimationType type);
+
+        /**
+         * Set a click animation. This will override the AnimationType and set it
+         * to Custom. Will run every time the button is pressed
+         */
+        void setClickAnimation(cocos2d::CCActionInterval* action);
+
+        /**
+         * Set a release animation. This will override the AnimationType and set it
+         * to Custom. Will run every time the button is released
+         */
+        void setReleaseAnimation(cocos2d::CCActionInterval* action);
+
+        /**
+         * Set a callback for when the button is activated
+         */
+        void setActivateCallback(ButtonCallback callback);
+
+        /**
+         * Set a callback for when the button is selected
+         */
+        void setSelectCallback(ButtonCallback callback);
+
+        /**
+         * Set a callback for when the button is unselected
+         */
+        void setUnselectCallback(ButtonCallback callback);
+
+        /**
+         * Set the touch priority of the Button
+         */
+        void setTouchPriority(int priority);
+        int getTouchPriority();
+
+        /**
+         * Set the touch multiplier, which increases the distance from the 
+         * center that the button can be pressed (default is 1)
+         */
+        void setTouchMultiplier(float multipler);
+        float getTouchMultiplier();
+
+        /**
+         * Set the scale multiplier, only used with AnimationType::Scale
+         * Will scale the button by this amount when pressed
+         */
+        void setScaleMultiplier(float multiplier);
+        float getScaleMultiplier();
+
+        /**
+         * Set the move offset, only used with AnimationType::Move
+         * Will move the button by this amount when pressed
+         */
+        void setMoveOffset(cocos2d::CCPoint const& offset);
+        cocos2d::CCPoint getMoveOffset();
+
+        /**
+         * Set how long the default animations will last when selected
+         */
+        void setSelectedDuration(float duration);
+        float getSelectedDuration();
+
+        /**
+         * Set how long the default animations will last when unselected
+         */
+        void setUnselectedDuration(float duration);
+        float getUnselectedDuration();
+
+        /**
+         * Set if the button can be clicked
+         */
+        virtual void setEnabled(bool enabled);
+        virtual bool isEnabled();
+        
+        /**
+         * Get the selected state of the button
+         */
+        virtual bool isSelected();
+
+        virtual void onEnter() override;
+        virtual void onExit() override;
+
+        virtual void selected();
+        virtual void unselected();
+        virtual void activate();
+
+        virtual void registerWithTouchDispatcher();
+
+        virtual bool ccTouchBegan(cocos2d::CCTouch* touch, cocos2d::CCEvent* event) override;
+        virtual void ccTouchMoved(cocos2d::CCTouch* touch, cocos2d::CCEvent* event) override;
+        virtual void ccTouchEnded(cocos2d::CCTouch* touch, cocos2d::CCEvent* event) override;
+        virtual void ccTouchCancelled(cocos2d::CCTouch* touch, cocos2d::CCEvent* event) override;
+
+    protected:
+        Button();
+        ~Button();
+
+        void setDefaults();
+        void resetDefaults();
+
+        cocos2d::CCActionInterval* clickActionForType();
+        cocos2d::CCActionInterval* releaseActionForType();
+
+        bool init(ButtonCallback activateCallback);
+        bool initWithNode(cocos2d::CCNode* node, ButtonCallback activateCallback);
+        bool initWithSprite(geode::ZStringView fileName, ButtonCallback activateCallback);
+        bool initWithSpriteFrameName(geode::ZStringView frameName, ButtonCallback activateCallback);
+        bool initWithLabel(geode::ZStringView text, geode::ZStringView font, ButtonCallback activateCallback);
+
+    private:
+        class Impl;
+        std::unique_ptr<Impl> m_impl;
+    };
+
+    /**
+     * A handler for buttons to share touches when they share a parent
+     * Shouldn't be messed with usually unless you are manually registering
+     */
+    class GEODE_DLL SharedButtonHandler {
+    public:
+        static SharedButtonHandler* get();
+
+        /**
+         * Returns true if the touch is within the button's rect (multiplied by the touch multiplier)
+         */
+        static bool containsTouch(Button* button, cocos2d::CCTouch* touch);
+
+        /**
+         * Register a button to share touches with (must be called in onEnter)
+         */
+        void registerButton(Button* button);
+
+        /**
+         * Unregister a button (must be called in onExit)
+         */
+        void unregisterButton(Button* button);
+        
+        /**
+         * Pass moves from ccTouchMoved to all buttons sharing a parent
+         */
+        void passMoveToButtons(Button* button, cocos2d::CCTouch* touch);
+
+        /**
+         * Pass click activate from one button to the active one
+         */
+        void passActivateToButtons();
+
+        /**
+         * Pass click cancelled from one button to the active one
+         */
+        void passCancelledToButtons();
+
+        /**
+         * Set an active button (should be called in ccTouchBegan)
+         */
+        void setActiveButton(Button* button);
+
+    protected:
+        SharedButtonHandler();
+        ~SharedButtonHandler();
+
+    private:
+        class Impl;
+        std::unique_ptr<Impl> m_impl;
+    };
+}

--- a/loader/src/ui/nodes/Button.cpp
+++ b/loader/src/ui/nodes/Button.cpp
@@ -1,0 +1,516 @@
+#include <Geode/ui/Button.hpp>
+#include <Geode/utils/cocos.hpp>
+
+using namespace geode::prelude;
+
+class Button::Impl final {
+public:
+    ButtonCallback m_activateCallback = nullptr;
+    ButtonCallback m_selectCallback = nullptr;
+    ButtonCallback m_unselectCallback = nullptr;
+
+    bool m_enabled = true;
+    bool m_selected = false;
+
+    int m_touchPriority = cocos2d::kCCMenuHandlerPriority;
+
+    float m_scaleMultiplier = 1.26;
+    float m_touchMultiplier = 1.f;
+
+    CCPoint m_offset = {0, -15};
+    
+    float m_selectedDuration = 0.3f;
+    float m_unselectedDuration = 0.4f;
+
+    AnimationType m_animationType = AnimationType::Scale;
+
+    geode::Ref<cocos2d::CCActionInterval> m_clickAction = nullptr;
+    geode::Ref<cocos2d::CCActionInterval> m_releaseAction = nullptr;
+
+    geode::Ref<cocos2d::CCActionInterval> m_activeClickAction = nullptr;
+    geode::Ref<cocos2d::CCActionInterval> m_activeReleaseAction = nullptr;
+
+    cocos2d::CCNode* m_displayNode = nullptr;
+
+    geode::Ref<cocos2d::CCNodeRGBA> m_defaults = nullptr;
+};
+
+Button::Button() : m_impl(std::make_unique<Impl>()) {}
+
+Button::~Button() {}
+
+Button* Button::create(ButtonCallback activateCallback) {
+    auto ret = new Button();
+    if (ret->init(std::move(activateCallback))) {
+        ret->autorelease();
+        return ret;
+    }
+    delete ret;
+    return nullptr;
+}
+
+Button* Button::createWithNode(CCNode* node, ButtonCallback activateCallback) {
+    auto ret = new Button();
+    if (ret->initWithNode(node, std::move(activateCallback))) {
+        ret->autorelease();
+        return ret;
+    }
+    delete ret;
+    return nullptr;
+}
+
+Button* Button::createWithSprite(ZStringView fileName, ButtonCallback activateCallback) {
+    auto ret = new Button();
+    if (ret->initWithSprite(std::move(fileName), std::move(activateCallback))) {
+        ret->autorelease();
+        return ret;
+    }
+    delete ret;
+    return nullptr;
+}
+
+Button* Button::createWithSpriteFrameName(ZStringView frameName, ButtonCallback activateCallback) {
+    auto ret = new Button();
+    if (ret->initWithSpriteFrameName(std::move(frameName),std::move(activateCallback))) {
+        ret->autorelease();
+        return ret;
+    }
+    delete ret;
+    return nullptr;
+}
+
+Button* Button::createWithLabel(ZStringView text, ZStringView font, ButtonCallback activateCallback) {
+    auto ret = new Button();
+    if (ret->initWithLabel(std::move(text), std::move(font), std::move(activateCallback))) {
+        ret->autorelease();
+        return ret;
+    }
+    delete ret;
+    return nullptr;
+}
+
+bool Button::init(ButtonCallback activateCallback) {
+    if (!CCNodeRGBA::init()) return false;
+    m_impl->m_defaults = CCNodeRGBA::create();
+    m_impl->m_activateCallback = std::move(activateCallback);
+
+    setCascadeColorEnabled(true);
+    setCascadeOpacityEnabled(true);
+    setAnchorPoint({0.5f, 0.5f});
+
+    return true;
+}
+
+bool Button::initWithNode(CCNode* node, ButtonCallback activateCallback) {
+    if (!Button::init(std::move(activateCallback))) return false;
+
+    m_impl->m_displayNode = node;
+
+    setContentSize(m_impl->m_displayNode->getScaledContentSize());
+    m_impl->m_displayNode->setPosition(getContentSize() * m_impl->m_displayNode->getAnchorPoint());
+
+    addChild(m_impl->m_displayNode);
+    return true;
+}
+
+bool Button::initWithSprite(ZStringView fileName, ButtonCallback activateCallback) {
+    if (!Button::init(std::move(activateCallback))) return false;
+
+    m_impl->m_displayNode = CCSprite::create(fileName.c_str());
+    if (!m_impl->m_displayNode) return false;
+
+    setContentSize(m_impl->m_displayNode->getScaledContentSize());
+    m_impl->m_displayNode->setPosition(getContentSize() * m_impl->m_displayNode->getAnchorPoint());
+
+    addChild(m_impl->m_displayNode);
+    return true;
+}
+
+bool Button::initWithSpriteFrameName(ZStringView frameName, ButtonCallback activateCallback) {
+    if (!Button::init(std::move(activateCallback))) return false;
+
+    m_impl->m_displayNode = CCSprite::createWithSpriteFrameName(frameName.c_str());
+    if (!m_impl->m_displayNode) return false;
+
+    setContentSize(m_impl->m_displayNode->getScaledContentSize());
+    m_impl->m_displayNode->setPosition(getContentSize() * m_impl->m_displayNode->getAnchorPoint());
+
+    addChild(m_impl->m_displayNode);
+    return true;
+}
+
+bool Button::initWithLabel(ZStringView text, ZStringView font, ButtonCallback activateCallback) {
+    if (!Button::init(std::move(activateCallback))) return false;
+
+    m_impl->m_displayNode = CCLabelBMFont::create(text.c_str(), font.c_str());
+    if (!m_impl->m_displayNode) return false;
+
+    setContentSize(m_impl->m_displayNode->getScaledContentSize());
+    m_impl->m_displayNode->setPosition(getContentSize() * m_impl->m_displayNode->getAnchorPoint());
+
+    addChild(m_impl->m_displayNode);
+    return true;
+}
+
+CCNode* Button::getDisplayNode() {
+    return m_impl->m_displayNode;
+}
+
+CCActionInterval* Button::clickActionForType() {
+    switch (m_impl->m_animationType) {
+        case AnimationType::None: {
+            return nullptr;
+        }
+        case AnimationType::Custom: {
+            return m_impl->m_clickAction;
+        }
+        case AnimationType::Scale: {
+            auto scaleTo = CCScaleTo::create(m_impl->m_selectedDuration, m_impl->m_defaults->getScale() * m_impl->m_scaleMultiplier);
+            return CCEaseBounceOut::create(scaleTo);
+        }
+        case AnimationType::Move: {
+            auto moveTo = CCMoveTo::create(m_impl->m_selectedDuration, m_impl->m_defaults->getPosition() + m_impl->m_offset);
+            return CCEaseInOut::create(moveTo, 1.5f);
+        }
+    }
+
+    return nullptr;
+}   
+
+CCActionInterval* Button::releaseActionForType() {
+    switch (m_impl->m_animationType) {
+        case AnimationType::None: {
+            return nullptr;
+        }
+        case AnimationType::Custom: {
+            return m_impl->m_releaseAction;
+        }
+        case AnimationType::Scale: {
+            auto scaleTo = CCScaleTo::create(m_impl->m_unselectedDuration, m_impl->m_defaults->getScale());
+            return CCEaseBounceOut::create(scaleTo);
+        }
+        case AnimationType::Move: {
+            auto moveTo = CCMoveTo::create(m_impl->m_selectedDuration, m_impl->m_defaults->getPosition());
+            return CCEaseInOut::create(moveTo, 2.f);
+        }
+    }
+    
+    return nullptr;
+}
+
+void Button::setAnimationType(AnimationType type) {
+    m_impl->m_animationType = type;
+}
+
+void Button::setClickAnimation(CCActionInterval* action) {
+    m_impl->m_animationType = AnimationType::Custom;
+    m_impl->m_clickAction = action;
+}
+
+void Button::setReleaseAnimation(CCActionInterval* action) {
+    m_impl->m_animationType = AnimationType::Custom;
+    m_impl->m_releaseAction = action;
+}
+
+void Button::setDefaults() {
+    m_impl->m_defaults->setScaleX(getScaleX());
+    m_impl->m_defaults->setScaleY(getScaleY());
+
+    m_impl->m_defaults->setSkewX(getSkewX());
+    m_impl->m_defaults->setSkewY(getSkewY());
+
+    m_impl->m_defaults->setRotationX(getRotationX());
+    m_impl->m_defaults->setRotationY(getRotationY());
+
+    m_impl->m_defaults->setPositionX(getPositionX());
+    m_impl->m_defaults->setPositionY(getPositionY());
+
+    m_impl->m_defaults->setContentSize(getContentSize());
+
+    m_impl->m_defaults->setZOrder(getZOrder());
+
+    m_impl->m_defaults->setOpacity(getOpacity());
+    m_impl->m_defaults->setColor(getColor());
+}
+
+void Button::resetDefaults() {
+    stopAction(m_impl->m_activeClickAction);
+    stopAction(m_impl->m_activeReleaseAction);
+
+    m_impl->m_activeClickAction = nullptr;
+    m_impl->m_activeReleaseAction = nullptr;
+
+    setScaleX(m_impl->m_defaults->getScaleX());
+    setScaleY(m_impl->m_defaults->getScaleY());
+
+    setSkewX(m_impl->m_defaults->getSkewX());
+    setSkewY(m_impl->m_defaults->getSkewY());
+
+    setRotationX(m_impl->m_defaults->getRotationX());
+    setRotationY(m_impl->m_defaults->getRotationY());
+
+    setPositionX(m_impl->m_defaults->getPositionX());
+    setPositionY(m_impl->m_defaults->getPositionY());
+
+    setContentSize(m_impl->m_defaults->getContentSize());
+
+    setZOrder(m_impl->m_defaults->getZOrder());
+
+    setOpacity(m_impl->m_defaults->getOpacity());
+    setColor(m_impl->m_defaults->getColor());
+}
+
+void Button::selected() {
+    if (!m_impl->m_enabled || m_impl->m_selected) return;
+    setDefaults();
+
+    stopAction(m_impl->m_activeClickAction);
+    stopAction(m_impl->m_activeReleaseAction);
+
+    m_impl->m_activeClickAction = clickActionForType();
+
+    if (m_impl->m_activeClickAction) {
+        runAction(m_impl->m_activeClickAction);
+    }
+
+    if (m_impl->m_selectCallback) m_impl->m_selectCallback(this);
+
+    m_impl->m_selected = true;
+}
+
+void Button::unselected() {
+    if (!m_impl->m_selected) return;
+    
+    stopAction(m_impl->m_activeClickAction);
+    stopAction(m_impl->m_activeReleaseAction);
+
+    m_impl->m_activeReleaseAction = releaseActionForType();
+
+    if (m_impl->m_activeReleaseAction) {
+        runAction(m_impl->m_activeReleaseAction);
+    }
+
+    if (m_impl->m_unselectCallback) m_impl->m_unselectCallback(this);
+
+    m_impl->m_selected = false;
+}
+
+void Button::activate() {
+    if (!m_impl->m_enabled) return;
+    m_impl->m_selected = false;
+
+    resetDefaults();
+
+    if (m_impl->m_activateCallback) m_impl->m_activateCallback(this);
+}
+
+void Button::setScaleMultiplier(float multiplier) {
+    m_impl->m_scaleMultiplier = multiplier;
+}
+
+float Button::getScaleMultiplier() {
+    return m_impl->m_scaleMultiplier;
+}
+
+void Button::setMoveOffset(cocos2d::CCPoint const& offset) {
+    m_impl->m_offset = std::move(offset);
+}
+
+cocos2d::CCPoint Button::getMoveOffset() {
+    return m_impl->m_offset;
+}
+
+void Button::setSelectedDuration(float duration) {
+    m_impl->m_selectedDuration = duration;
+}
+
+float Button::getSelectedDuration() {
+    return m_impl->m_selectedDuration;
+}
+
+void Button::setUnselectedDuration(float duration) {
+    m_impl->m_unselectedDuration = duration;
+}
+
+float Button::getUnselectedDuration() {
+    return m_impl->m_unselectedDuration;
+}
+
+void Button::setEnabled(bool enabled) {
+    m_impl->m_enabled = enabled;
+    if (!m_impl->m_enabled) {
+        unselected();
+    }
+}
+
+bool Button::isEnabled() {
+    return m_impl->m_enabled;
+}
+
+bool Button::isSelected() {
+    return m_impl->m_selected;
+}
+
+void Button::onEnter() {
+    CCNodeRGBA::onEnter();
+    SharedButtonHandler::get()->registerButton(this);
+    registerWithTouchDispatcher();
+}
+
+void Button::onExit() {
+    CCNodeRGBA::onExit();
+    SharedButtonHandler::get()->unregisterButton(this);
+    CCTouchDispatcher::get()->removeDelegate(this);
+}
+
+bool Button::ccTouchBegan(CCTouch* touch, CCEvent* event) {
+    if (!nodeIsVisible(this)) return false;
+
+    if (SharedButtonHandler::containsTouch(this, touch)) {
+        SharedButtonHandler::get()->setActiveButton(this);
+        return true;
+    }
+    return false;
+}
+
+void Button::ccTouchMoved(CCTouch* touch, CCEvent* event) {
+    SharedButtonHandler::get()->passMoveToButtons(this, touch);
+}
+
+void Button::ccTouchEnded(CCTouch* touch, CCEvent* event) {
+    SharedButtonHandler::get()->passActivateToButtons();
+}
+
+void Button::ccTouchCancelled(CCTouch* touch, CCEvent* event) {
+    SharedButtonHandler::get()->passCancelledToButtons();
+}
+
+void Button::setTouchPriority(int priority) {
+    m_impl->m_touchPriority = priority;
+}
+
+int Button::getTouchPriority() {
+    return m_impl->m_touchPriority;
+}
+
+void Button::setTouchMultiplier(float multipler) {
+    m_impl->m_touchMultiplier = multipler;
+}
+
+float Button::getTouchMultiplier() {
+    return m_impl->m_touchMultiplier;
+}
+
+void Button::registerWithTouchDispatcher() {
+    CCTouchDispatcher::get()->addTargetedDelegate(this, m_impl->m_touchPriority, true);
+}
+
+void Button::setActivateCallback(ButtonCallback callback) {
+    m_impl->m_activateCallback = std::move(callback);
+}
+
+void Button::setSelectCallback(ButtonCallback callback) {
+    m_impl->m_selectCallback = std::move(callback);
+}
+
+void Button::setUnselectCallback(ButtonCallback callback) {
+    m_impl->m_unselectCallback = std::move(callback);
+}
+
+class SharedButtonHandler::Impl final {
+public:
+    Button* m_activeNeighbor = nullptr;
+    std::unordered_map<cocos2d::CCNode*, std::unordered_set<Button*>> m_buttons;
+};
+
+SharedButtonHandler::SharedButtonHandler() : m_impl(std::make_unique<Impl>()) {}
+
+SharedButtonHandler::~SharedButtonHandler() {}
+
+SharedButtonHandler* SharedButtonHandler::get() {
+    static SharedButtonHandler handler;
+    return &handler;
+}
+
+void SharedButtonHandler::registerButton(Button* button) {
+    auto parent = button->getParent();
+    if (!parent) return;
+
+    m_impl->m_buttons[parent].insert(button);
+}
+
+void SharedButtonHandler::unregisterButton(Button* button) {
+    auto parent = button->getParent();
+    if (!parent) return;
+
+    if (m_impl->m_activeNeighbor == button) m_impl->m_activeNeighbor = nullptr;
+
+    auto& buttons = m_impl->m_buttons[parent];
+
+    buttons.erase(button);
+    if (buttons.empty()) {
+        m_impl->m_buttons.erase(parent);
+    }
+}
+
+void SharedButtonHandler::passMoveToButtons(Button* button, CCTouch* touch) {
+    auto parent = button->getParent();
+    if (!parent) return;
+
+    auto& buttons = m_impl-> m_buttons[parent];
+
+    bool hasNewNeighbor = false;
+
+    for (auto button : buttons) {
+        if (!hasNewNeighbor && !m_impl->m_activeNeighbor && !button->isSelected() && SharedButtonHandler::containsTouch(button, touch)) {
+            m_impl->m_activeNeighbor = button;
+            hasNewNeighbor = true;
+            button->selected();
+        }
+        else if (button->isSelected() && !SharedButtonHandler::containsTouch(button, touch)) {
+            if (m_impl->m_activeNeighbor == button) {
+                m_impl->m_activeNeighbor = nullptr;
+            }
+            button->unselected();
+        }
+    }
+}
+
+void SharedButtonHandler::passActivateToButtons() {
+    if (!m_impl->m_activeNeighbor || !m_impl->m_activeNeighbor->isSelected()) return;
+
+    m_impl->m_activeNeighbor->unselected();
+    m_impl->m_activeNeighbor->activate();
+    m_impl->m_activeNeighbor = nullptr;
+}
+
+void SharedButtonHandler::passCancelledToButtons() {
+    if (!m_impl->m_activeNeighbor) return;
+
+    m_impl->m_activeNeighbor->unselected();
+    m_impl->m_activeNeighbor = nullptr;
+}
+
+bool SharedButtonHandler::containsTouch(Button* button, CCTouch* touch) {
+    float multiplier = button->getTouchMultiplier();
+
+    auto local = button->convertToNodeSpace(touch->getLocation());
+
+    float width = button->getContentWidth();
+    float height = button->getContentHeight();
+
+    float scaledWidth = width * multiplier;
+    float scaledHeight = height * multiplier;
+
+    float dx = (scaledWidth - width) * 0.5f;
+    float dy = (scaledHeight - height) * 0.5f;
+
+    auto rect = cocos2d::CCRect{-dx, -dy, scaledWidth, scaledHeight};
+
+    return rect.containsPoint(local);
+}
+
+void SharedButtonHandler::setActiveButton(Button* button) {
+    m_impl->m_activeNeighbor = button;
+    m_impl->m_activeNeighbor->selected();
+}


### PR DESCRIPTION
CCMenuItems require CCMenus, which can be a little annoying at times. Why not have something that just works as a button?

- Create a button with a label, sprite, or node
- Can customize callbacks for select, unselect, and activate
- Can use custom animation actions for select and unselect
- Easily use existing animations, Scale and Move, from CCMenuItemSpriteExtra (Scale is default)
- State resetting, so no worries if your action modifies some attribute on the button
- Shared buttons
  - All buttons sharing a parent will automatically have their touch shared with each other
  - Works similar to how CCMenus worked, but handled on a per button basis