### PR TITLE
Add $HOME/.steam/debian-installation to linux install script

### DIFF
--- a/installer/linux/install.sh
+++ b/installer/linux/install.sh
@@ -71,7 +71,7 @@ find_gd_installation() {
     verbose_log "Searching for Geometry Dash..."
     local DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 
-    for GD_IDX in "$DATA_HOME/Steam" "$HOME/Steam" "$HOME/.var/app/com.valvesoftware.Steam/data/Steam" "$HOME/snap/steam/common/.steam/steam"; do
+    for GD_IDX in "$DATA_HOME/Steam" "$HOME/Steam" "$HOME/.steam/debian-installation" "$HOME/.var/app/com.valvesoftware.Steam/data/Steam" "$HOME/snap/steam/common/.steam/steam"; do
         local PATH_TEST="$GD_IDX/steamapps/common/Geometry Dash"
         verbose_log "- Testing path ${YELLOW}$PATH_TEST${NC}"
 


### PR DESCRIPTION
On my Debian-based (Linux Mint) system the native Steam client has two steamapps directories.

- `$HOME/.local/share/Steam/steamapps`
- `$HOME/.steam/debian-installation/steamapps`

A symlink exists from `$HOME/.steam/steam` to `$HOME/.steam/debian-installation` if that is preferred.
