### PR TITLE
Make modify_cast more powerful

### DIFF
--- a/loader/include/Geode/modify/Modify.hpp
+++ b/loader/include/Geode/modify/Modify.hpp
@@ -629,7 +629,7 @@ namespace geode::cast {
      * modify_cast<HookedGJBaseGameLayer*>(myHookedPlayLayer);
      */
     template<typename Target, typename Original>
-    constexpr Target custom_modify_cast(Original original) {
+    constexpr Target modify_cast(Original original) {
         // If Target is probably (fully checked later) a modify class, then this is its modify base, otherwise it's void
         using TargetBase = geode::internal::ModifyBase<std::remove_pointer_t<Target>>;
         // If Original is probably (fully checked later) a modify class, then this is its modify base, otherwise it's void


### PR DESCRIPTION
The original `modify_cast` was only able to cast a non-modify class to a modify class.

This pull request enables it to do the reverse, cast from a modify class to a non-modify class as well.

It also enables it to cast between 2 modify classes.