### PR TITLE
Remove unnecessary null pointer checks before delete

### DIFF
--- a/loader/src/platform/android/ModImpl.cpp
+++ b/loader/src/platform/android/ModImpl.cpp
@@ -18,9 +18,7 @@ Result<> Mod::Impl::loadPlatformBinary() {
     auto so =
         dlopen(utils::string::pathToString(this->getBinaryPath()).c_str(), RTLD_LAZY);
     if (so) {
-        if (m_platformInfo) {
-            delete m_platformInfo;
-        }
+        delete m_platformInfo;
         m_platformInfo = new PlatformInfo{so};
 
         auto geodeImplicitEntry = findSymbolOrMangled<void(*)()>(so, "geodeImplicitEntry", "_Z17geodeImplicitEntryv");

--- a/loader/src/platform/ios/ModImpl.cpp
+++ b/loader/src/platform/ios/ModImpl.cpp
@@ -19,9 +19,7 @@ Result<> Mod::Impl::loadPlatformBinary() {
     auto dylib =
         dlopen(utils::string::pathToString(this->getBinaryPath()).c_str(), RTLD_LAZY);
     if (dylib) {
-        if (m_platformInfo) {
-            delete m_platformInfo;
-        }
+        delete m_platformInfo;
         m_platformInfo = new PlatformInfo { dylib };
 
         auto geodeImplicitEntry = findSymbolOrMangled<void(*)()>(dylib, "geodeImplicitEntry", "_Z17geodeImplicitEntryv");

--- a/loader/src/platform/mac/ModImpl.cpp
+++ b/loader/src/platform/mac/ModImpl.cpp
@@ -19,9 +19,7 @@ Result<> Mod::Impl::loadPlatformBinary() {
     auto dylib =
         dlopen(utils::string::pathToString(this->getBinaryPath()).c_str(), RTLD_LAZY);
     if (dylib) {
-        if (m_platformInfo) {
-            delete m_platformInfo;
-        }
+        delete m_platformInfo;
         m_platformInfo = new PlatformInfo { dylib };
 
         auto geodeImplicitEntry = findSymbolOrMangled<void(*)()>(dylib, "geodeImplicitEntry", "_Z17geodeImplicitEntryv");

--- a/loader/src/platform/windows/ModImpl.cpp
+++ b/loader/src/platform/windows/ModImpl.cpp
@@ -56,9 +56,7 @@ std::string getLastWinError() {
 Result<> Mod::Impl::loadPlatformBinary() {
     auto load = LoadLibraryW(this->getBinaryPath().c_str());
     if (load) {
-        if (m_platformInfo) {
-            delete m_platformInfo;
-        }
+        delete m_platformInfo;
         m_platformInfo = new PlatformInfo { load };
 
         auto geodeImplicitEntry = findSymbolOrMangled<void(*)()>(load, "geodeImplicitEntry", "_geodeImplicitEntry@0");


### PR DESCRIPTION
This PR fixes #1722.

## Problem
The codebase had redundant null pointer checks before `delete` operations:
```cpp
if (m_platformInfo) {
    delete m_platformInfo;
}
```

## Solution
According to the C++ standard, `delete nullptr` is guaranteed to be safe and does nothing. The [ISO C++ FAQ explicitly states](https://isocpp.org/wiki/faq/freestore-mgmt#delete-handles-null):
> "Do I need to check for null before delete p? **No.** The C++ language guarantees that delete p will do nothing if p is null."

## Changes
Simplified the code in all four platform implementations:
- `loader/src/platform/android/ModImpl.cpp`
- `loader/src/platform/ios/ModImpl.cpp`
- `loader/src/platform/mac/ModImpl.cpp`
- `loader/src/platform/windows/ModImpl.cpp`

All changed from:
```cpp
if (m_platformInfo) {
    delete m_platformInfo;
}
```

To:
```cpp
delete m_platformInfo;
```

Closes #1722