### PR TITLE
Clamp number inputs to min/max range instead of resetting to default

### DIFF
--- a/loader/src/ui/mods/settings/SettingNodeV3.hpp
+++ b/loader/src/ui/mods/settings/SettingNodeV3.hpp
@@ -120,7 +120,22 @@ protected:
         m_input->setScale(.7f);
         m_input->setCommonFilter(std::is_floating_point_v<typename S::ValueType> ? CommonFilter::Float : CommonFilter::Int);
         m_input->setCallback([this, setting](auto const& str) {
-            this->setValue(numFromString<ValueType>(str).unwrapOr(setting->getDefaultValue()), m_input);
+            auto result = numFromString<ValueType>(str);
+            if (result) {
+                auto value = result.unwrap();
+                // Clamp to min/max range if defined
+                if (auto min = setting->getMinValue()) {
+                    value = std::max(*min, value);
+                }
+                if (auto max = setting->getMaxValue()) {
+                    value = std::min(*max, value);
+                }
+                this->setValue(value, m_input);
+            }
+            else {
+                // If parsing fails, reset to default
+                this->setValue(setting->getDefaultValue(), m_input);
+            }
         });
         if (!setting->isInputEnabled()) {
             m_input->getBGSprite()->setVisible(false);


### PR DESCRIPTION
This PR fixes #1111.

## Problem
When entering a number outside the allowed range (min/max) in mod settings, the value would reset to the default value instead of clamping to the nearest bound.

## Solution
Modified the `NumberSettingNodeV3` text input callback to clamp values to the min/max range.

## Behavior Changes
| Scenario | Before | After |
|----------|--------|-------|
| Value < min | Resets to default | ✅ Clamps to min |
| Value > max | Resets to default | ✅ Clamps to max |
| Invalid input | Resets to default | Resets to default (unchanged) |

This improves UX especially when users have slider bypass hacks and need to type values directly.

Closes #1111