### PR TITLE
Fix deprecation text overlapping restart required text

### DIFF
--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -665,7 +665,8 @@ void ModItem::updateState() {
             m_bg->setColor(to3B(ColorProvider::get()->color("mod-list-version-bg-updates-available"_spr)));
             m_bg->setOpacity(isGeodeTheme() ? 25 : 90);
         }
-        else {
+        else if (!wantsRestart) {
+            // Don't show deprecated label if restart is required to avoid overlap
             m_deprecatedLabel->setVisible(true);
             elementToReplaceWithOtherAbnormalElement->setVisible(false);
             m_bg->setColor(to3B(ColorProvider::get()->color("mod-list-version-bg-deprecated"_spr)));


### PR DESCRIPTION
This PR fixes #1886.

## Problem
When a mod was both deprecated AND required a restart, both the "Deprecated" and "Restart Required" labels would be shown at the same position, causing them to overlap visually.

## Solution
Added a condition to not show the deprecated label when restart is required. This follows the same pattern already used for the "Outdated" label.

**Before:**
- Both labels visible and overlapping

**After:**
- Only "Restart Required" shown (takes precedence)

Closes #1886