### PR TITLE
Add autoResizeWidth() method to SimpleTextArea

### DIFF
--- a/loader/include/Geode/ui/TextArea.hpp
+++ b/loader/include/Geode/ui/TextArea.hpp
@@ -50,6 +50,12 @@ namespace geode {
         std::vector<cocos2d::CCLabelBMFont*> getLines();
         float getHeight();
         float getLineHeight();
+        /**
+         * Automatically resize the width to fit the content.
+         * This is useful when you want the text area to shrink/expand
+         * to exactly fit the text without wrapping.
+         */
+        void autoResizeWidth();
     protected:
         SimpleTextArea();
         ~SimpleTextArea() override;

--- a/loader/src/ui/nodes/TextArea.cpp
+++ b/loader/src/ui/nodes/TextArea.cpp
@@ -336,3 +336,13 @@ float SimpleTextArea::getHeight() {
 float SimpleTextArea::getLineHeight() {
     return m_impl->m_lineHeight;
 }
+
+void SimpleTextArea::autoResizeWidth() {
+    float maxWidth = 0.f;
+    for (CCLabelBMFont* line : m_impl->m_lines) {
+        maxWidth = std::max(maxWidth, line->getContentSize().width * m_impl->m_scale);
+    }
+    if (maxWidth > 0.f) {
+        this->setWidth(maxWidth);
+    }
+}


### PR DESCRIPTION
This PR implements #1361.

## New Feature

Added `autoResizeWidth()` method to `SimpleTextArea` that automatically resizes the width to fit the content.

## Use Case

This is useful when you want the text area to shrink/expand to exactly fit the text without wrapping:

```cpp
auto textArea = SimpleTextArea::create("Hello World");
textArea->autoResizeWidth(); // Width now fits text exactly
```

## Implementation

The method calculates the maximum width of all lines and sets the width accordingly.

## API

```cpp
/**
 * Automatically resize the width to fit the content.
 * This is useful when you want the text area to shrink/expand
 * to exactly fit the text without wrapping.
 */
void autoResizeWidth();
```

Closes #1361