### PR TITLE
Add Enable All / Disable All mods buttons

### DIFF
--- a/loader/src/ui/mods/ModsLayer.cpp
+++ b/loader/src/ui/mods/ModsLayer.cpp
@@ -372,6 +372,30 @@ bool ModsLayer::init() {
     reloadBtn->setID("reload-button");
     rightActionsMenu->addChild(reloadBtn);
 
+    // Enable All Mods button
+    auto enableAllSpr = createGeodeCircleButton(
+        CCSprite::createWithSpriteFrameName("GJ_checkMark_001.png"), 1.f,
+        CircleBaseSize::Medium
+    );
+    enableAllSpr->setScale(.7f);
+    auto enableAllBtn = CCMenuItemSpriteExtra::create(
+        enableAllSpr, this, menu_selector(ModsLayer::onEnableAllMods)
+    );
+    enableAllBtn->setID("enable-all-button");
+    rightActionsMenu->addChild(enableAllBtn);
+
+    // Disable All Mods button
+    auto disableAllSpr = createGeodeCircleButton(
+        CCSprite::createWithSpriteFrameName("GJ_deleteIcon_001.png"), 1.f,
+        CircleBaseSize::Medium
+    );
+    disableAllSpr->setScale(.7f);
+    auto disableAllBtn = CCMenuItemSpriteExtra::create(
+        disableAllSpr, this, menu_selector(ModsLayer::onDisableAllMods)
+    );
+    disableAllBtn->setID("disable-all-button");
+    rightActionsMenu->addChild(disableAllBtn);
+
     auto settingsSpr = createGeodeCircleButton(
         CCSprite::createWithSpriteFrameName("settings.png"_spr), 1.f,
         CircleBaseSize::Medium
@@ -754,6 +778,40 @@ void ModsLayer::onBack(CCObject*) {
     // To avoid memory overloading, clear caches after leaving the layer
     server::clearServerCaches(true);
     ModListSource::clearAllCaches();
+}
+void ModsLayer::onEnableAllMods(CCObject*) {
+    createQuickPopup(
+        "Enable All Mods",
+        "Are you sure you want to <cg>enable</c> all mods?",
+        "Cancel", "Enable All",
+        [this](auto, bool btn2) {
+            if (btn2) {
+                for (auto& mod : Loader::get()->getAllMods()) {
+                    if (!mod->isOrWillBeEnabled()) {
+                        mod->enable();
+                    }
+                }
+                this->refreshList();
+            }
+        }
+    );
+}
+void ModsLayer::onDisableAllMods(CCObject*) {
+    createQuickPopup(
+        "Disable All Mods",
+        "Are you sure you want to <cr>disable</c> all mods?",
+        "Cancel", "Disable All",
+        [this](auto, bool btn2) {
+            if (btn2) {
+                for (auto& mod : Loader::get()->getAllMods()) {
+                    if (mod->isOrWillBeEnabled()) {
+                        mod->disable();
+                    }
+                }
+                this->refreshList();
+            }
+        }
+    );
 }
 void ModsLayer::onGoToPage(CCObject*) {
     auto popup = SetIDPopup::create(m_lists.at(m_currentSource)->getPage() + 1, 1, m_currentSource->getPageCount().value(), "Go to Page", "Go", true, 1, 60.f, false, false);

--- a/loader/src/ui/mods/ModsLayer.hpp
+++ b/loader/src/ui/mods/ModsLayer.hpp
@@ -88,6 +88,8 @@ protected:
     void onSettings(CCObject*);
     void onKeybinds(CCObject*);
     void onBack(CCObject*);
+    void onEnableAllMods(CCObject*);
+    void onDisableAllMods(CCObject*);
 
     void updateState();
 


### PR DESCRIPTION
This PR implements #1052 and #1401.

## New Features

Added two new buttons to the mod list UI (in the right actions menu):

1. **Enable All Mods** (checkmark icon) - Enables all currently disabled mods
2. **Disable All Mods** (X icon) - Disables all currently enabled mods

## Why This Is Useful

Users with 100+ mods (like the requester in #1401) often want to:
- Quickly disable all mods for troubleshooting
- Enable a specific subset of mods for different activities (creating vs playing)
- Start fresh without manually clicking each mod

## Implementation Details

- Both actions show a confirmation popup before proceeding
- Uses existing mod enable/disable API
- Refreshes the mod list after action completes
- Buttons are placed in the right actions menu next to the reload button

## Screenshots

The buttons appear as circular icons in the right-side menu of the mod list.

---

Closes #1052
Closes #1401