### PR TITLE
Clamp slider setting values

### DIFF
--- a/loader/src/ui/mods/settings/SettingNodeV3.hpp
+++ b/loader/src/ui/mods/settings/SettingNodeV3.hpp
@@ -226,10 +226,17 @@ protected:
         }
         this->setValue(value, static_cast<CCNode*>(sender));
     }
+    
     void onSlider(CCObject*) {
         auto value = this->valueFromSlider(m_slider->m_touchLogic->m_thumb->getValue());
 
         if (value != this->getValue()) {
+            if (auto min = this->getSetting()->getMinValue()) {
+                value = std::max(*min, value);
+            }
+            if (auto max = this->getSetting()->getMaxValue()) {
+                value = std::min(*max, value);
+            }
             this->setValue(value, m_slider);
         }
     }


### PR DESCRIPTION
Clamps the settings slider. Same way it is done with the arrows, you don't need to rework settings to do this. This is already following an existing precedent too. 