### PR TITLE
Long name fixes

### DIFF
--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -582,7 +582,7 @@ void ModItem::updateState() {
 
     auto titleSpace = m_display == ModListDisplay::Grid ?
         CCSize(m_obContentSize.width - 10, 35) :
-        CCSize(m_obContentSize.width - 150, m_obContentSize.height - 5);
+        CCSize(m_obContentSize.width - 145, m_obContentSize.height - 5);
 
     // Divide by scale of info container since that actually determines the size
     // (Since the scale of m_titleContainer and m_developers is managed by its layout)

--- a/loader/src/ui/mods/list/ModItem.cpp
+++ b/loader/src/ui/mods/list/ModItem.cpp
@@ -40,7 +40,13 @@ bool ModItem::init(ModSource&& source) {
     m_titleContainer->setID("title-container");
     m_titleContainer->setAnchorPoint({ .0f, .5f });
 
-    m_titleLabel = CCLabelBMFont::create(m_source.getMetadata().getName().c_str(), "bigFont.fnt");
+    StringBuffer title;
+    title.append("{:.40}", m_source.getMetadata().getName());
+    if (m_source.getMetadata().getName().size() > 40) {
+        title.append("...");
+    }
+
+    m_titleLabel = CCLabelBMFont::create(title.c_str(), "bigFont.fnt");
     m_titleLabel->setID("title-label");
     m_titleContainer->addChild(m_titleLabel);
 
@@ -576,7 +582,7 @@ void ModItem::updateState() {
 
     auto titleSpace = m_display == ModListDisplay::Grid ?
         CCSize(m_obContentSize.width - 10, 35) :
-        CCSize(m_obContentSize.width / 1.75 - m_obContentSize.height, m_obContentSize.height - 5);
+        CCSize(m_obContentSize.width - 150, m_obContentSize.height - 5);
 
     // Divide by scale of info container since that actually determines the size
     // (Since the scale of m_titleContainer and m_developers is managed by its layout)

--- a/loader/src/ui/mods/popups/ModPopup.cpp
+++ b/loader/src/ui/mods/popups/ModPopup.cpp
@@ -164,11 +164,17 @@ bool ModPopup::init(ModSource&& src) {
     // Lil padding
     auto devAndTitlePos = m_titleContainer->getContentHeight() + 5;
 
-    auto title = CCLabelBMFont::create(m_source.getMetadata().getName().c_str(), "bigFont.fnt");
-    title->limitLabelWidth(m_titleContainer->getContentWidth() - devAndTitlePos, .45f, .1f);
-    title->setAnchorPoint({ .0f, .5f });
-    title->setID("mod-name-label");
-    m_titleContainer->addChildAtPosition(title, Anchor::TopLeft, ccp(devAndTitlePos, -m_titleContainer->getContentHeight() * .25f));
+    StringBuffer title;
+    title.append("{:.40}", m_source.getMetadata().getName());
+    if (m_source.getMetadata().getName().size() > 40) {
+        title.append("...");
+    }
+
+    auto titleLabel = CCLabelBMFont::create(title.c_str(), "bigFont.fnt");
+    titleLabel->limitLabelWidth(m_titleContainer->getContentWidth() - devAndTitlePos, .45f, .1f);
+    titleLabel->setAnchorPoint({ .0f, .5f });
+    titleLabel->setID("mod-name-label");
+    m_titleContainer->addChildAtPosition(titleLabel, Anchor::TopLeft, ccp(devAndTitlePos, -m_titleContainer->getContentHeight() * .25f));
 
     auto by = "By " + m_source.formatDevelopers();
     auto dev = CCLabelBMFont::create(by.c_str(), "goldFont.fnt");


### PR DESCRIPTION
This PR addresses the issue found in April Fools mod updates. Long names just make things break.
So what I have done is:
- Limit names to 40 characters
- Add `...` if they are longer
- Also remove weird math for title space (???), since there was overlap with the download count with its implementation.