### PR TITLE
fix MDTextArea culling

### DIFF
--- a/loader/src/ui/nodes/MDTextArea.cpp
+++ b/loader/src/ui/nodes/MDTextArea.cpp
@@ -88,7 +88,7 @@ public:
 
         // so that's why based MDContentLayer expects itself
         // to have a CCMenu :-)
-        if (m_content && getParent()) {
+        if (m_content) {
             for (auto child : CCArrayExt<CCNode*>(m_content->getChildren())) {
                 auto y = this->getPositionY() + child->getPositionY();
                 child->setVisible(
@@ -167,13 +167,12 @@ bool MDTextArea::init(std::string str, CCSize const& size) {
     auto content = MDContentLayer::create(m_impl->m_content, m_impl->m_size.width, m_impl->m_size.height);
     m_impl->m_scrollLayer->m_contentLayer = content;
     m_impl->m_scrollLayer->addChild(content);
-
-    m_impl->m_scrollLayer->m_contentLayer->addChild(m_impl->m_content);
+    content->addChild(m_impl->m_content);
 
     m_impl->m_scrollLayer->setTouchEnabled(true);
 
     this->addChild(m_impl->m_scrollLayer);
-
+    
     this->updateLabel();
 
     return true;


### PR DESCRIPTION
before:
<img width="1924" height="1085" alt="image" src="https://github.com/user-attachments/assets/abe29bbe-f344-44b5-9db0-e421f3207b1f" />

after:
<img width="1930" height="1090" alt="image" src="https://github.com/user-attachments/assets/27ce6795-0e0d-4fcf-bc3b-084545647b26" />