### PR TITLE
Fix German translation for installer

### DIFF
--- a/installer/windows/Language Files/GermanExtra.nsh
+++ b/installer/windows/Language Files/GermanExtra.nsh
@@ -1,18 +1,18 @@
 !insertmacro LANGFILE_EXT German
 
 !pragma warning disable 6030
-${LangFileString} MUI_TEXT_WELCOME_INFO_TEXT "Dieses Setup führt Sie durch die Installation von $(^NameDA).$\r$\n$\r$\nBevor Sie die Installation starten, stellen Sie sicher, dass Geometry Dash nicht rennt.$\r$\n$\r$\n$_CLICK"
-${LangFileString} MUI_UNTEXT_WELCOME_INFO_TEXT "Dieses Setup führt Sie durch die Deinstallation von $(^NameDA).$\r$\n$\r$\nBevor Sie die Deinstallation starten, stellen Sie sicher, dass Geometry Dash nicht rennt.$\r$\n$\r$\n$_CLICK"
+${LangFileString} MUI_TEXT_WELCOME_INFO_TEXT "Dieses Setup führt Sie durch die Installation von $(^NameDA).$\r$\n$\r$\nBevor Sie die Installation starten, stellen Sie sicher, dass Geometry Dash geschlossen ist.$\r$\n$\r$\n$_CLICK"
+${LangFileString} MUI_UNTEXT_WELCOME_INFO_TEXT "Dieses Setup führt Sie durch die Deinstallation von $(^NameDA).$\r$\n$\r$\nBevor Sie die Deinstallation starten, stellen Sie sicher, dass Geometry Dash geschlossen ist.$\r$\n$\r$\n$_CLICK"
 !pragma warning default 6030
 
 ; installer
 
-${LangFileString} GEODE_TEXT_GD_MISSING "$\r$\n$\r$\nIn diesem Pfad ist Geometry Dash nicht installiert!"
-${LangFileString} GEODE_TEXT_GD_OLD "$\r$\n$\r$\nIhre Geometry Dash Version ist zu alt für diese Version von Geode!"
-${LangFileString} GEODE_TEXT_GD_RUNNING "Please close Geometry Dash before installing Geode."
-${LangFileString} GEODE_TEXT_MOD_LOADER_ALREADY_INSTALLED "In diesem Pfad sind andere Mods installiert!$\r$\nSie werden von Geode überschrieben. (the dll trademark)"
-${LangFileString} GEODE_TEXT_INSTALLING_VCREDIST "Installing VS Runtime. Check the taskbar for any new open windows..."
+${LangFileString} GEODE_TEXT_GD_MISSING "$\r$\n$\r$\nGeometry Dash ist in diesem Ordner nicht installiert!"
+${LangFileString} GEODE_TEXT_GD_OLD "$\r$\n$\r$\nIhre Geometry Dash-Version ist zu alt für diese Version von Geode!"
+${LangFileString} GEODE_TEXT_GD_RUNNING "Bitte schließen Sie Geometry Dash, bevor Sie Geode installieren."
+${LangFileString} GEODE_TEXT_MOD_LOADER_ALREADY_INSTALLED "In diesem Ordner sind andere Mods installiert!$\r$\nDiese werden von Geode überschrieben."
+${LangFileString} GEODE_TEXT_INSTALLING_VCREDIST "Die VS Runtime wird installiert. Bitte achten Sie auf neue Fenster in der Taskleiste..."
 
 ; uninstaller
 
-${LangFileString} GEODE_UNTEXT_GEODE_MISSING "In diesem Pfad ist Geode nicht installiert!"
+${LangFileString} GEODE_UNTEXT_GEODE_MISSING "In diesem Ordner ist Geode nicht installiert!"


### PR DESCRIPTION
## Summary
This PR refines the German translation strings for the installer and uninstaller to sound more natural.

## Changes
- **Terminology:** Changed "nicht rennt" (incorrect literal translation) to "geschlossen".
- **Translation:** Translated 2 strings that haven't been translated.
- **Clarity:** Changed "Pfad" to "Ordner". (sounds more natural)
- **Formatting:** Added proper German hyphenation for "Geometry Dash-Version".