### PR TITLE
Translate English strings to Polish in installer

### DIFF
--- a/installer/windows/Language Files/PolishExtra.nsh
+++ b/installer/windows/Language Files/PolishExtra.nsh
@@ -9,7 +9,7 @@ ${LangFileString} MUI_UNTEXT_WELCOME_INFO_TEXT "Instalator przeprowadzi Cię prz
 
 ${LangFileString} GEODE_TEXT_GD_MISSING "$\r$\n$\r$\nGeometry Dash nie jest zainstalowane w tym folderze!"
 ${LangFileString} GEODE_TEXT_GD_OLD "$\r$\n$\r$\nTwoja wersja Geometry Dash jest zbyt stara dla tej wersji Geode!"
-${LangFileString} GEODE_TEXT_GD_RUNNING "Proszę zamknąć Geometry Dash Przed Instalacją Geode!"
+${LangFileString} GEODE_TEXT_GD_RUNNING "Proszę zamknąć Geometry Dash przed instalacją Geode!"
 ${LangFileString} GEODE_TEXT_MOD_LOADER_ALREADY_INSTALLED "W tym folderze zainstalowane są inne modyfikacje!$\r$\nZostaną one zastąpione przez Geode. (the dll trademark)"
 ${LangFileString} GEODE_TEXT_INSTALLING_VCREDIST "Instalowanie VS Runtime. Sprawdż pasek zadań dla otwartych okien"
 


### PR DESCRIPTION
Fixed Polish Translation

Changed GEODE_TEXT_GD_RUNNING "Please close Geometry Dash before installing Geode."
To GEODE_TEXT_GD_RUNNING "Proszę zamknąć Geometry Dash Przed Instalacją Geode!"

Changed GEODE_TEXT_INSTALLING_VCREDIST "Installing VS Runtime. Check the taskbar for any new open windows..."
To GEODE_TEXT_INSTALLING_VCREDIST "Instalowanie VS Runtime. Sprawdż pasek zadań dla otwartych okien"