### PR TITLE
Add padding to AxisLayout and SimpleAxisLayout

### DIFF
--- a/loader/include/Geode/ui/Layout.hpp
+++ b/loader/include/Geode/ui/Layout.hpp
@@ -70,6 +70,36 @@ enum class AxisAlignment {
     Between,
 };
 
+/**
+ * Specifies the padding inside a layout
+ */
+struct Padding final {
+    float left = 0.f;
+    float top = 0.f;
+    float right = 0.f;
+    float bottom = 0.f;
+
+    constexpr Padding() = default;
+    constexpr Padding(float left, float top, float right, float bottom)
+        : left(left), top(top), right(right), bottom(bottom) {}
+
+    constexpr static Padding uniform(float padding) {
+        return { padding, padding, padding, padding };
+    }
+
+    constexpr static Padding symmetric(float horizontal, float vertical) {
+        return { horizontal, vertical, horizontal, vertical };
+    }
+
+    constexpr static Padding horizontal(float horizontal) {
+        return { horizontal, 0.f, horizontal, 0.f };
+    }
+
+    constexpr static Padding vertical(float vertical) {
+        return { 0.f, vertical, 0.f, vertical };
+    }
+};
+
 constexpr float AXISLAYOUT_DEFAULT_MIN_SCALE = 0.65f;
 constexpr int AXISLAYOUT_DEFAULT_PRIORITY = 0;
 
@@ -243,6 +273,7 @@ public:
     std::optional<float> getAutoGrowAxis() const;
     float getDefaultMinScale() const;
     float getDefaultMaxScale() const;
+    Padding getPadding() const;
 
     AxisLayout* setAxis(Axis axis);
     /**
@@ -305,6 +336,11 @@ public:
      */
     AxisLayout* ignoreInvisibleChildren(bool ignore = true);
     bool isIgnoreInvisibleChildren() const;
+    /**
+     * Sets the padding inside the layout, which is the empty space between the
+     * layout's border and its children. The default is set to 0 on all sides
+     */
+    AxisLayout* setPadding(Padding const& padding);
 };
 
 /**

--- a/loader/include/Geode/ui/SimpleAxisLayout.hpp
+++ b/loader/include/Geode/ui/SimpleAxisLayout.hpp
@@ -189,6 +189,11 @@ public:
      */
     SimpleAxisLayout* ignoreInvisibleChildren(bool ignore = true);
     bool isIgnoreInvisibleChildren() const;
+    /**
+     * Sets the padding inside the layout, which is the empty space between the
+     * layout's border and its children. The default is set to 0 on all sides
+     */
+    SimpleAxisLayout* setPadding(Padding const& padding);
 
     Axis getAxis() const;
     AxisScaling getMainAxisScaling() const;
@@ -200,6 +205,7 @@ public:
     float getGap() const;
     std::optional<float> getMinRelativeScale() const;
     std::optional<float> getMaxRelativeScale() const;
+    Padding getPadding() const;
 };
 
 class GEODE_DLL SimpleRowLayout final : public SimpleAxisLayout {

--- a/loader/src/cocos2d-ext/AxisLayout.cpp
+++ b/loader/src/cocos2d-ext/AxisLayout.cpp
@@ -140,8 +140,30 @@ public:
     bool m_growCrossAxis = false;
     std::optional<float> m_autoGrowAxisMinLength;
     std::pair<float, float> m_defaultScaleLimits = { AXISLAYOUT_DEFAULT_MIN_SCALE, 1 };
+    Padding m_padding = { 0.f, 0.f, 0.f, 0.f };
 
     Impl(Axis axis) : BaseAxisLayoutImpl(axis, 5.f) {}
+
+    float axisPadding() const {
+        if (m_axis == Axis::Row) {
+            return m_padding.left + m_padding.right;
+        }
+        return m_padding.top + m_padding.bottom;
+    }
+
+    float crossPadding() const {
+        if (m_axis == Axis::Row) {
+            return m_padding.top + m_padding.bottom;
+        }
+        return m_padding.left + m_padding.right;
+    }
+
+    AxisPosition availableForLayout(CCNode* on) const {
+        auto available = nodeAxis(on, m_axis, 1.f / on->getScale());
+        available.axisLength = available.axisLength - this->axisPadding();
+        available.crossLength = available.crossLength - this->crossPadding();
+        return available;
+    }
 
     struct Row : public CCObject {
         float nextOverflowScaleDownFactor;
@@ -316,7 +338,7 @@ public:
         float crossLength;
         auto res = CCArray::create();
 
-        auto available = nodeAxis(on, m_axis, 1.f / on->getScale());
+        auto available = this->availableForLayout(on);
 
         auto fit = [&](CCArray* nodes) {
             nextAxisScalableLength = 0.f;
@@ -504,7 +526,7 @@ public:
             return;
         }
 
-        auto available = nodeAxis(on, m_axis, 1.f / on->getScale());
+        auto available = this->availableForLayout(on);
         if (available.axisLength <= 0.f) {
             return;
         }
@@ -562,14 +584,14 @@ public:
             available.crossLength = totalRowCrossLength;
             if (m_axis == Axis::Row) {
                 on->setContentSize({
-                    available.axisLength,
-                    totalRowCrossLength,
+                    available.axisLength + m_padding.left + m_padding.right,
+                    totalRowCrossLength + m_padding.top + m_padding.bottom,
                 });
             }
             else {
                 on->setContentSize({
-                    totalRowCrossLength,
-                    available.axisLength,
+                    totalRowCrossLength + m_padding.left + m_padding.right,
+                    available.axisLength + m_padding.top + m_padding.bottom,
                 });
             }
         }
@@ -718,10 +740,16 @@ public:
                     } break;
                 }
                 if (m_axis == Axis::Row) {
-                    node->setPosition(axisPos, rowCrossPos + crossOffset);
+                    node->setPosition(
+                        m_padding.left + axisPos,
+                        m_padding.bottom + rowCrossPos + crossOffset
+                    );
                 }
                 else {
-                    node->setPosition(rowCrossPos + crossOffset, axisPos);
+                    node->setPosition(
+                        m_padding.left + rowCrossPos + crossOffset,
+                        m_padding.bottom + axisPos
+                    );
                 }
                 prev = opts;
                 ix++;
@@ -793,14 +821,15 @@ void AxisLayout::apply(CCNode* on) {
     }
 
     if (m_impl->m_autoGrowAxisMinLength.has_value()) {
-        if (totalLength < m_impl->m_autoGrowAxisMinLength.value()) {
-            totalLength = m_impl->m_autoGrowAxisMinLength.value();
+        auto totalOuterLength = totalLength + m_impl->axisPadding();
+        if (totalOuterLength < m_impl->m_autoGrowAxisMinLength.value()) {
+            totalOuterLength = m_impl->m_autoGrowAxisMinLength.value();
         }
         if (m_impl->m_axis == Axis::Row) {
-            on->setContentSize({ totalLength, on->getContentSize().height });
+            on->setContentSize({ totalOuterLength, on->getContentSize().height });
         }
         else {
-            on->setContentSize({ on->getContentSize().width, totalLength });
+            on->setContentSize({ on->getContentSize().width, totalOuterLength });
         }
     }
 
@@ -815,25 +844,34 @@ void AxisLayout::apply(CCNode* on) {
 CCSize AxisLayout::getSizeHint(CCNode* on) const {
     // Ideal is single row / column with no scaling
     auto nodes = m_impl->getNodesToPosition(on);
-    float length = 0.f;
-    float cross = 0.f;
+    float innerLength = 0.f;
+    float innerCross = 0.f;
     for (auto& node : CCArrayExt<CCNode*>(nodes)) {
         auto axis = nodeAxis(node, m_impl->m_axis, 1.f);
-        length += axis.axisLength;
-        if (axis.crossLength > cross) {
-            axis.crossLength = cross;
+        innerLength += axis.axisLength;
+        if (axis.crossLength > innerCross) {
+            axis.crossLength = innerCross;
         }
     }
+
+    auto available = nodeAxis(on, m_impl->m_axis, 1.f);
+    auto axisPadding = m_impl->axisPadding();
+    auto crossPadding = m_impl->crossPadding();
+    auto availableInnerAxis = available.axisLength - axisPadding;
+
     if (auto l = m_impl->m_autoGrowAxisMinLength) {
-        length = std::max(length, *l);
+        innerLength = std::max(innerLength, *l - axisPadding);
     }
     // No overflow
     else {
-        length = std::min(length, nodeAxis(on, m_impl->m_axis, 1.f).axisLength);
+        innerLength = std::min(innerLength, availableInnerAxis);
     }
     if (!m_impl->m_allowCrossAxisOverflow) {
-        cross = nodeAxis(on, m_impl->m_axis, 1.f).crossLength;
+        innerCross = available.crossLength - crossPadding;
     }
+
+    auto length = innerLength + axisPadding;
+    auto cross = innerCross + crossPadding;
     if (m_impl->m_axis == Axis::Row) {
         return { length, cross };
     }
@@ -880,6 +918,10 @@ float AxisLayout::getDefaultMinScale() const {
 }
 float AxisLayout::getDefaultMaxScale() const {
     return m_impl->m_defaultScaleLimits.second;
+}
+
+Padding AxisLayout::getPadding() const {
+    return m_impl->m_padding;
 }
 
 AxisLayout* AxisLayout::setAxis(Axis axis) {
@@ -937,6 +979,11 @@ AxisLayout* AxisLayout::ignoreInvisibleChildren(bool ignore) {
 }
 bool AxisLayout::isIgnoreInvisibleChildren() const {
     return m_impl->m_ignoreInvisibleChildren;
+}
+
+AxisLayout* AxisLayout::setPadding(Padding const& padding) {
+    m_impl->m_padding = padding;
+    return this;
 }
 
 AxisLayout::AxisLayout(Axis axis) : m_impl(std::make_unique<Impl>(axis)) {}

--- a/loader/src/cocos2d-ext/SimpleAxisLayout.cpp
+++ b/loader/src/cocos2d-ext/SimpleAxisLayout.cpp
@@ -72,6 +72,8 @@ public:
     std::unordered_map<CCNode*, float> m_originalScalesPerNode;
     std::unordered_map<CCNode*, float> m_relativeScalesPerNode;
 
+    Padding m_padding = { 0.f, 0.f, 0.f, 0.f };
+
     Impl(Axis axis, SimpleAxisLayout* parent) : BaseAxisLayoutImpl(axis, 0.f), m_layout(parent) {
         switch (axis) {
             case Axis::Column:
@@ -165,6 +167,46 @@ public:
         }
     }
 
+    float axisPadding() const {
+        if (m_axis == Axis::Column) {
+            return m_padding.top + m_padding.bottom;
+        }
+        return m_padding.left + m_padding.right;
+    }
+
+    float crossPadding() const {
+        if (m_axis == Axis::Column) {
+            return m_padding.left + m_padding.right;
+        }
+        return m_padding.top + m_padding.bottom;
+    }
+
+    float axisStartPadding() const {
+        if (m_axis == Axis::Column) {
+            return m_padding.bottom;
+        }
+        return m_padding.left;
+    }
+
+    float crossStartPadding() const {
+        if (m_axis == Axis::Column) {
+            return m_padding.left;
+        }
+        return m_padding.bottom;
+    }
+
+    float getInnerContentWidth(CCNode* on) const {
+        return this->getContentWidth(on) - this->crossPadding();
+    }
+
+    float getInnerContentHeight(CCNode* on) const {
+        return this->getContentHeight(on) - this->axisPadding();
+    }
+
+    void setOuterContentWidth(CCNode* on, float width) {
+        this->setContentWidth(on, width + this->crossPadding());
+    }
+
     float getScale(CCNode* on) const {
         return on->getScale();
     }
@@ -210,7 +252,7 @@ public:
     // get the maximum allowed scale for the node
     // based on the layout's width and the node's width
     float getMaxCrossScale(CCNode* layout, CCNode* on) {
-        auto const layoutWidth = this->getContentWidth(layout);
+        auto const layoutWidth = this->getInnerContentWidth(layout);
         auto const width = this->getContentWidth(on) * this->getUncommittedScale(on);
         auto const maxAllowedScale = layoutWidth / width;
         auto const maxScale = this->getMaxScale(on);
@@ -223,7 +265,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateCrossScaling
     std::unordered_map<CCNode*, float> scales;
 
     auto maxWidth = std::numeric_limits<float>::min();
-    auto layoutWidth = this->getContentWidth(layout);
+    auto layoutWidth = this->getInnerContentWidth(layout);
 
     // get the limits we are working with
     for (auto node : nodes) {
@@ -235,9 +277,9 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateCrossScaling
 
     switch (m_crossAxisScaling) {
         case AxisScaling::Grow:
-            if (m_minCrossAxis == std::nullopt) m_minCrossAxis = layoutWidth;
+            if (m_minCrossAxis == std::nullopt) m_minCrossAxis = this->getContentWidth(layout);
             // grow the layout to fit the widest node
-            layoutWidth = std::max(m_minCrossAxis.value(), maxWidth);
+            layoutWidth = std::max(m_minCrossAxis.value() - this->crossPadding(), maxWidth);
             break;
         case AxisScaling::Fit:
             // fit the layout to the widest node
@@ -247,7 +289,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateCrossScaling
             break;
     }
 
-    this->setContentWidth(layout, layoutWidth);
+    this->setOuterContentWidth(layout, layoutWidth);
 
     // get the scales we need for current limits
     for (auto node : nodes) {
@@ -285,7 +327,8 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateMainScaling(
     std::unordered_map<CCNode*, float> scales;
 
     auto totalHeight = totalGap;
-    auto layoutHeight = this->getContentHeight(layout);
+    auto layoutHeight = this->getInnerContentHeight(layout);
+    auto outerLayoutHeight = this->getContentHeight(layout);
 
     // get the limits we are working with
     for (auto node : nodes) {
@@ -295,13 +338,15 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateMainScaling(
 
     switch (m_mainAxisScaling) {
         case AxisScaling::Grow:
-            if (m_minMainAxis == std::nullopt) m_minMainAxis = layoutHeight;
+            if (m_minMainAxis == std::nullopt) m_minMainAxis = outerLayoutHeight;
             // grow the layout to fit all the nodes
-            layoutHeight = std::max(m_minMainAxis.value(), totalHeight);
+            outerLayoutHeight = std::max(m_minMainAxis.value(), totalHeight + this->axisPadding());
+            layoutHeight = outerLayoutHeight - this->axisPadding();
             break;
         case AxisScaling::Fit:
             // fit the layout to all the nodes
             layoutHeight = totalHeight;
+            outerLayoutHeight = totalHeight + this->axisPadding();
             break;
         case AxisScaling::ScaleDownGaps:
             // remove gaps if needed to fit the layout
@@ -316,7 +361,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateMainScaling(
             break;
     }
 
-    this->setContentHeight(layout, layoutHeight);
+    this->setContentHeight(layout, outerLayoutHeight);
 
     std::unordered_map<ScalingPriority, std::vector<CCNode*>> sortedNodes;
     std::unordered_map<ScalingPriority, float> reducedHeightPerPriority;
@@ -502,7 +547,7 @@ std::unordered_map<CCNode*, float> SimpleAxisLayout::Impl::calculateMainScaling(
 
 void SimpleAxisLayout::Impl::applyCrossPositioning(CCNode* layout, std::vector<CCNode*> const& nodes) {
     auto maxWidth = 0.f;
-    auto layoutWidth = this->getContentWidth(layout);
+    auto layoutWidth = this->getInnerContentWidth(layout);
     for (auto node : nodes) {
         auto const width = this->getContentWidth(node) * this->getScale(node);
         if (width > maxWidth) {
@@ -513,8 +558,8 @@ void SimpleAxisLayout::Impl::applyCrossPositioning(CCNode* layout, std::vector<C
     // reapply grow/fit since main scaling may have changed the max width
     switch (m_crossAxisScaling) {
         case AxisScaling::Grow:
-            if (m_minCrossAxis == std::nullopt) m_minCrossAxis = layoutWidth;
-            layoutWidth = std::max(m_minCrossAxis.value(), maxWidth);
+            if (m_minCrossAxis == std::nullopt) m_minCrossAxis = this->getContentWidth(layout);
+            layoutWidth = std::max(m_minCrossAxis.value() - this->crossPadding(), maxWidth);
             break;
         case AxisScaling::Fit:
             layoutWidth = maxWidth;
@@ -523,7 +568,8 @@ void SimpleAxisLayout::Impl::applyCrossPositioning(CCNode* layout, std::vector<C
             break;
     }
 
-    this->setContentWidth(layout, layoutWidth);
+    this->setOuterContentWidth(layout, layoutWidth);
+    layoutWidth = this->getInnerContentWidth(layout);
 
     // cross axis direction only exists to disambiguate the alignment
     CrossAxisAlignment alignment = m_crossAxisAlignment;
@@ -552,13 +598,13 @@ void SimpleAxisLayout::Impl::applyCrossPositioning(CCNode* layout, std::vector<C
             // remainingWidth is the space left after the node is placed
             // and width * .5 is added since the anchor point is in the middle
             case CrossAxisAlignment::Start:
-                this->setPositionX(node, width * 0.5f);
+                this->setPositionX(node, this->crossStartPadding() + width * 0.5f);
                 break;
             case CrossAxisAlignment::Center:
-                this->setPositionX(node, remainingWidth * 0.5f + width * 0.5f);
+                this->setPositionX(node, this->crossStartPadding() + remainingWidth * 0.5f + width * 0.5f);
                 break;
             case CrossAxisAlignment::End:
-                this->setPositionX(node, remainingWidth + width * 0.5f);
+                this->setPositionX(node, this->crossStartPadding() + remainingWidth + width * 0.5f);
                 break;
             default:
                 break;
@@ -572,7 +618,7 @@ void SimpleAxisLayout::Impl::applyMainPositioning(CCNode* layout, std::vector<CC
         auto const height = this->getContentHeight(node) * this->getScale(node);
         totalHeight += height;
     }
-    auto const layoutHeight = this->getContentHeight(layout);
+    auto const layoutHeight = this->getInnerContentHeight(layout);
 
     auto gapPercentage = 1.f;
     if (m_mainAxisScaling == AxisScaling::ScaleDownGaps) {
@@ -607,8 +653,8 @@ void SimpleAxisLayout::Impl::applyMainPositioning(CCNode* layout, std::vector<CC
             this->setScale(spacer, 1.f);
             auto const height = spacer->getGrow() * spacerGap;
             this->setContentHeight(spacer, height);
-            this->setContentWidth(spacer, this->getContentWidth(layout));
-            this->setPositionX(spacer, this->getContentWidth(layout) / 2);
+            this->setContentWidth(spacer, this->getInnerContentWidth(layout));
+            this->setPositionX(spacer, this->crossStartPadding() + this->getInnerContentWidth(layout) / 2);
         }
     }
     else {
@@ -679,13 +725,13 @@ void SimpleAxisLayout::Impl::applyMainPositioning(CCNode* layout, std::vector<CC
             // items are laid out from top to bottom
             // so the center is subtracted from the offset
             case AxisDirection::BackToFront:
-                this->setPositionY(node, offset - height / 2);
+                this->setPositionY(node, this->axisStartPadding() + offset - height / 2);
                 offset -= height + extraGap;
                 break;
             // items are laid out from bottom to top
             // so the center is added to the offset
             case AxisDirection::FrontToBack:
-                this->setPositionY(node, offset + height / 2);
+                this->setPositionY(node, this->axisStartPadding() + offset + height / 2);
                 offset += height + extraGap;
                 break;
         }
@@ -855,6 +901,11 @@ bool SimpleAxisLayout::isIgnoreInvisibleChildren() const {
     return m_impl->m_ignoreInvisibleChildren;
 }
 
+SimpleAxisLayout* SimpleAxisLayout::setPadding(Padding const& padding) {
+    m_impl->m_padding = padding;
+    return this;
+}
+
 Axis SimpleAxisLayout::getAxis() const {
     return m_impl->m_axis;
 }
@@ -893,6 +944,10 @@ std::optional<float> SimpleAxisLayout::getMinRelativeScale() const {
 
 std::optional<float> SimpleAxisLayout::getMaxRelativeScale() const {
     return m_impl->m_maxRelativeScale;
+}
+
+Padding SimpleAxisLayout::getPadding() const {
+    return m_impl->m_padding;
 }
 
 SimpleRowLayout::SimpleRowLayout() : SimpleAxisLayout(Axis::Row) {}


### PR DESCRIPTION
Adds optional padding settings into layouts, to offset the children inside it

<img width="1692" height="1028" alt="image" src="https://github.com/user-attachments/assets/3dc47568-2d08-40b5-9c27-a06c73ce17a3" />

(i will push DevTools changes when this gets merged for obvious reasons)