### PR TITLE
Add Keybind Modifier Fallthrough

### DIFF
--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -426,13 +426,13 @@ void Loader::Impl::populateModList(std::vector<ModMetadata>& modQueue) {
             // now we run the code that already existed before the 
             // modifier fallthrough functionality was added but we
             // loop it through all modifier combinations we just found
+            bool imeActive = CCIMEDispatcher::sharedDispatcher()->hasDelegate();
+
             for(const auto& keybind : keybindsToCheck) {
                 auto it = m_keybindSettings.find(keybind);
                 if (it == m_keybindSettings.end()) {
                     continue;
                 }
-
-                bool imeActive = CCIMEDispatcher::sharedDispatcher()->hasDelegate();
 
                 if (down) {
                     for (auto& setting : it->second) {

--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -406,32 +406,56 @@ void Loader::Impl::populateModList(std::vector<ModMetadata>& modQueue) {
                 });
             }
 
-            auto it = m_keybindSettings.find(keybind);
-            if (it == m_keybindSettings.end()) {
-                return ListenerResult::Propagate;
-            }
+            // build up all keybinds to look for, starting with the most specific
+            // (most modifiers) to least specific (least modifiers)
+            // this is for modifier fallthrough functionality
+            std::vector<Keybind> keybindsToCheck;
+            int baseMask = keybind.modifiers.value; 
 
-            bool imeActive = CCIMEDispatcher::sharedDispatcher()->hasDelegate();
-
-            if (down) {
-                for (auto& setting : it->second) {
-                    if (imeActive && !setting->getAllowInTextInputs()) {
-                        continue;
-                    }
-                    if (!repeat) m_activeKeybinds[setting.get()] = keybind;
-                    if (KeybindSettingPressedEventV3(setting->getModID(), setting->getKey()).send(keybind, down, repeat, data.timestamp)) {
-                        return ListenerResult::Stop;
-                    }
-                }
-            } else {
-                for (auto& setting : it->second) {
-                    auto it2 = m_activeKeybinds.find(setting.get());
-                    if (it2 != m_activeKeybinds.end() && it2->second.key == data.key) {
-                        KeybindSettingPressedEventV3(setting->getModID(), setting->getKey()).send(keybind, down, repeat, data.timestamp);
-                        m_activeKeybinds.erase(it2);
-                    }
+            for (int submask = baseMask; ; submask = (submask - 1) & baseMask) {
+                keybindsToCheck.push_back(Keybind(keybind.key, submask));
+                
+                if (submask == 0) {
+                    break; 
                 }
             }
+
+            std::ranges::sort(keybindsToCheck, [](const Keybind& a, const Keybind& b) {
+                return std::popcount(a.modifiers.value) > std::popcount(b.modifiers.value);
+            });
+
+            // now we run the code that already existed before the 
+            // modifier fallthrough functionality was added but we
+            // loop it through all modifier combinations we just found
+            for(const auto& keybind : keybindsToCheck) {
+                auto it = m_keybindSettings.find(keybind);
+                if (it == m_keybindSettings.end()) {
+                    continue;
+                }
+
+                bool imeActive = CCIMEDispatcher::sharedDispatcher()->hasDelegate();
+
+                if (down) {
+                    for (auto& setting : it->second) {
+                        if (imeActive && !setting->getAllowInTextInputs()) {
+                            continue;
+                        }
+                        if (!repeat) m_activeKeybinds[setting.get()] = keybind;
+                        if (KeybindSettingPressedEventV3(setting->getModID(), setting->getKey()).send(keybind, down, repeat, data.timestamp)) {
+                            return ListenerResult::Stop;
+                        }
+                    }
+                } else {
+                    for (auto& setting : it->second) {
+                        auto it2 = m_activeKeybinds.find(setting.get());
+                        if (it2 != m_activeKeybinds.end() && it2->second.key == data.key) {
+                            KeybindSettingPressedEventV3(setting->getModID(), setting->getKey()).send(keybind, down, repeat, data.timestamp);
+                            m_activeKeybinds.erase(it2);
+                        }
+                    }
+                }
+            }
+            
             return ListenerResult::Propagate;
         }).leak();
 

--- a/loader/src/loader/LoaderImpl.cpp
+++ b/loader/src/loader/LoaderImpl.cpp
@@ -406,8 +406,7 @@ void Loader::Impl::populateModList(std::vector<ModMetadata>& modQueue) {
                 });
             }
 
-            // build up all keybinds to look for, starting with the most specific
-            // (most modifiers) to least specific (least modifiers)
+            // build up all keybinds to look for, starting with the most specific to least specific
             // this is for modifier fallthrough functionality
             std::vector<Keybind> keybindsToCheck;
             int baseMask = keybind.modifiers.value; 


### PR DESCRIPTION
This PR adds keybind modifier fallthrough for keybinds settings listeners. In reality this means that if the user presses something like CTRL+ALT+S, it will look for a match for CTRL+ALT+S, then for matches for CTRL+S and ALT+S and then for matches for just S. The search stops once a hit that doesn't propagate is found.

This PR is meant to bring the settings functionality more in line with user expectations from the vanilla game, where modifiers can modify the outcome of the action but they never prevent it from happening - Editor CTRL+A still moves the block to the left in vanilla, even though CTRL+D duplicates it. Another common complaint this would address is people being "unable to place checkpoints" when having their jump key bound to Left CTRL.

Lastly I'd like to mention that an alternate proposal also exists (also proposed by me) where instead of this being a default behavior there would be an explicit *Any* modifier defined for settings, which would explicitly make settings listen to the keybind regardless of the modifier. However, IMO, the behavior in this PR matches user expectations more.