### PR TITLE
map joystick inputs to key inputs on Android

### DIFF
--- a/loader/src/platform/android/input.cpp
+++ b/loader/src/platform/android/input.cpp
@@ -513,3 +513,16 @@ extern "C"
 JNIEXPORT void JNICALL Java_com_geode_launcher_utils_GeodeUtils_inputDeviceRemoved(JNIEnv*, jobject, jint deviceId, jint eventSource) {
     geode::AndroidInputDeviceEvent().send(deviceId, geode::AndroidInputDeviceStatus::Removed);
 }
+
+extern "C"
+JNIEXPORT void JNICALL Java_com_geode_launcher_utils_GeodeUtils_resizeSurface(
+    JNIEnv* env, jobject, jint width, jint height
+) {
+    auto fWidth = static_cast<float>(width);
+    auto fHeight = static_cast<float>(height);
+
+    cocos2d::CCEGLView::sharedOpenGLView()->setFrameSize(fWidth, fHeight);
+    cocos2d::CCDirector::sharedDirector()->updateScreenScale({fWidth, fHeight});
+    cocos2d::CCDirector::sharedDirector()->setViewport();
+    cocos2d::CCDirector::sharedDirector()->setProjection(cocos2d::kCCDirectorProjection2D);
+}

--- a/loader/src/platform/android/main.cpp
+++ b/loader/src/platform/android/main.cpp
@@ -63,6 +63,7 @@ extern "C" [[gnu::visibility("default")]] jint JNI_OnLoad(JavaVM* vm, void* rese
     }
 
     reportPlatformCapability("internal_callbacks_v2");
+    reportPlatformCapability("resize_callbacks");
 
     geodeEntry(nullptr);
     return JNI_VERSION_1_6;


### PR DESCRIPTION
i still do not believe that geode v4 implicitly mapped these to directional inputs, but maybe i should