### PR TITLE
Separate geode::Priority into a new header

### DIFF
--- a/loader/include/Geode/Loader.hpp
+++ b/loader/include/Geode/Loader.hpp
@@ -8,5 +8,6 @@
 #include "loader/ModEvent.hpp"
 #include "loader/Setting.hpp"
 #include "loader/Dirs.hpp"
+#include "loader/Priority.hpp"
 
 #include <Geode/DefaultInclude.hpp>

--- a/loader/include/Geode/loader/Priority.hpp
+++ b/loader/include/Geode/loader/Priority.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+namespace geode {
+    class Priority {
+    public:
+        /// @brief First priority, used for running hooks before all others
+        /// @note Should be used with caution, consider using VeryEarly instead
+        static inline constexpr int First = -3000;
+
+        /// @brief Very early priority, used for running hooks very early
+        /// @note Recommended over First
+        static inline constexpr int VeryEarly = -2000;
+
+        /// @brief Early priority, used for running hooks early
+        static inline constexpr int Early = -1000;
+
+        /// @brief Normal priority, used for running hooks at the normal time
+        static inline constexpr int Normal = 0;
+
+        /// @brief Late priority, used for running hooks late
+        static inline constexpr int Late = 1000;
+
+        /// @brief Very late priority, used for running hooks very late
+        /// @note Recommended over Last
+        static inline constexpr int VeryLate = 2000;
+
+        /// @brief Last priority, used for running hooks after all others
+        /// @note Should be used with caution, consider using VeryLate instead
+        static inline constexpr int Last = 3000;
+
+        /// @brief First pre priority, used for running hooks before all others
+        /// @note Should be used with caution, consider using VeryEarlyPre instead
+        static inline constexpr int FirstPre = First;
+
+        /// @brief Very early pre priority, used for running hooks very early
+        /// @note Recommended over FirstPre
+        static inline constexpr int VeryEarlyPre = VeryEarly;
+
+        /// @brief Early pre priority, used for running hooks early
+        static inline constexpr int EarlyPre = Early;
+
+        /// @brief Normal pre priority, used for running hooks at the normal time
+        static inline constexpr int NormalPre = Normal;
+
+        /// @brief Late pre priority, used for running hooks late
+        static inline constexpr int LatePre = Late;
+
+        /// @brief Very late pre priority, used for running hooks very late
+        /// @note Recommended over LastPre
+        static inline constexpr int VeryLatePre = VeryLate;
+
+        /// @brief Last pre priority, used for running hooks after all others
+        /// @note Should be used with caution, consider using VeryLatePre instead
+        static inline constexpr int LastPre = Last;
+
+        /// @brief First post priority, used for running hooks before all others
+        /// @note Should be used with caution, consider using VeryEarlyPost instead
+        static inline constexpr int FirstPost = Last;
+
+        /// @brief Very early post priority, used for running hooks very early
+        /// @note Recommended over FirstPost
+        static inline constexpr int VeryEarlyPost = VeryLate;
+
+        /// @brief Early post priority, used for running hooks early
+        static inline constexpr int EarlyPost = Late;
+
+        /// @brief Normal post priority, used for running hooks at the normal time
+        static inline constexpr int NormalPost = Normal;
+
+        /// @brief Late post priority, used for running hooks late
+        static inline constexpr int LatePost = Early;
+
+        /// @brief Very late post priority, used for running hooks very late
+        /// @note Recommended over LastPost
+        static inline constexpr int VeryLatePost = VeryEarly;
+
+        /// @brief Last post priority, used for running hooks after all others
+        /// @note Should be used with caution, consider using VeryLatePost instead
+        static inline constexpr int LastPost = First;
+
+        /// @brief Stub priority, used for stubbing out functions & editing parameters
+        /// @note Should be used with extreme caution, may cause mod incompatibilities
+        static inline constexpr int Stub = -4000;
+
+        /// @brief Replace priority, used for replacing original functions
+        /// @note Should be used with extreme caution, may cause mod incompatibilities
+        static inline constexpr int Replace = 4000;
+    };
+}

--- a/loader/include/Geode/modify/Modify.hpp
+++ b/loader/include/Geode/modify/Modify.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "AsStaticFunction.hpp"
 #include "Field.hpp"
+#include <Geode/loader/Priority.hpp>
 #include <Geode/Enums.hpp>
 #include "IDManager.hpp"
 
@@ -108,94 +109,6 @@
             this->m_hooks[#ClassName_ "::" #ClassName_] = hook;                                                  \
         }                                                                                                        \
     } while (0);
-
-namespace geode {
-    class Priority {
-    public:
-        /// @brief First priority, used for running hooks before all others
-        /// @note Should be used with caution, consider using VeryEarly instead
-        static inline constexpr int32_t First = -3000;
-
-        /// @brief Very early priority, used for running hooks very early
-        /// @note Recommended over First
-        static inline constexpr int32_t VeryEarly = -2000;
-
-        /// @brief Early priority, used for running hooks early
-        static inline constexpr int32_t Early = -1000;
-
-        /// @brief Normal priority, used for running hooks at the normal time
-        static inline constexpr int32_t Normal = 0;
-
-        /// @brief Late priority, used for running hooks late
-        static inline constexpr int32_t Late = 1000;
-
-        /// @brief Very late priority, used for running hooks very late
-        /// @note Recommended over Last
-        static inline constexpr int32_t VeryLate = 2000;
-
-        /// @brief Last priority, used for running hooks after all others
-        /// @note Should be used with caution, consider using VeryLate instead
-        static inline constexpr int32_t Last = 3000;
-
-        /// @brief First pre priority, used for running hooks before all others
-        /// @note Should be used with caution, consider using VeryEarlyPre instead
-        static inline constexpr int32_t FirstPre = First;
-
-        /// @brief Very early pre priority, used for running hooks very early
-        /// @note Recommended over FirstPre
-        static inline constexpr int32_t VeryEarlyPre = VeryEarly;
-
-        /// @brief Early pre priority, used for running hooks early
-        static inline constexpr int32_t EarlyPre = Early;
-
-        /// @brief Normal pre priority, used for running hooks at the normal time
-        static inline constexpr int32_t NormalPre = Normal;
-
-        /// @brief Late pre priority, used for running hooks late
-        static inline constexpr int32_t LatePre = Late;
-
-        /// @brief Very late pre priority, used for running hooks very late
-        /// @note Recommended over LastPre
-        static inline constexpr int32_t VeryLatePre = VeryLate;
-
-        /// @brief Last pre priority, used for running hooks after all others
-        /// @note Should be used with caution, consider using VeryLatePre instead
-        static inline constexpr int32_t LastPre = Last;
-
-        /// @brief First post priority, used for running hooks before all others
-        /// @note Should be used with caution, consider using VeryEarlyPost instead
-        static inline constexpr int32_t FirstPost = Last;
-
-        /// @brief Very early post priority, used for running hooks very early
-        /// @note Recommended over FirstPost
-        static inline constexpr int32_t VeryEarlyPost = VeryLate;
-
-        /// @brief Early post priority, used for running hooks early
-        static inline constexpr int32_t EarlyPost = Late;
-
-        /// @brief Normal post priority, used for running hooks at the normal time
-        static inline constexpr int32_t NormalPost = Normal;
-
-        /// @brief Late post priority, used for running hooks late
-        static inline constexpr int32_t LatePost = Early;
-
-        /// @brief Very late post priority, used for running hooks very late
-        /// @note Recommended over LastPost
-        static inline constexpr int32_t VeryLatePost = VeryEarly;
-
-        /// @brief Last post priority, used for running hooks after all others
-        /// @note Should be used with caution, consider using VeryLatePost instead
-        static inline constexpr int32_t LastPost = First;
-
-        /// @brief Stub priority, used for stubbing out functions & editing parameters
-        /// @note Should be used with extreme caution, may cause mod incompatibilities
-        static inline constexpr int32_t Stub = -4000;
-
-        /// @brief Replace priority, used for replacing original functions
-        /// @note Should be used with extreme caution, may cause mod incompatibilities
-        static inline constexpr int32_t Replace = 4000;
-    };
-}
 
 namespace geode::modifier {
     template <class Derived, class Base>

--- a/loader/src/ui/mods/GeodeStyle.cpp
+++ b/loader/src/ui/mods/GeodeStyle.cpp
@@ -3,7 +3,8 @@
 #include <Geode/utils/ColorProvider.hpp>
 #include <Geode/binding/ButtonSprite.hpp>
 #include <Geode/ui/LoadingSpinner.hpp>
-#include <Geode/ui//NineSlice.hpp>
+#include <Geode/ui/NineSlice.hpp>
+#include <Geode/loader/Priority.hpp>
 
 $on_mod(Loaded) {
     // todo: these names should probably be shorter so they fit in SSO...


### PR DESCRIPTION
Because it has more uses than hook priority now, I guess.