### PR TITLE
Window resize event and a few OverlayManager changes

### DIFF
--- a/loader/include/Geode/ui/OverlayManager.hpp
+++ b/loader/include/Geode/ui/OverlayManager.hpp
@@ -5,6 +5,8 @@
 
 namespace geode {
     class GEODE_DLL OverlayManager final : public cocos2d::CCNode {
+    protected:
+        bool init() override;
     public:
         static OverlayManager* get();
     };

--- a/loader/include/Geode/ui/WindowResizeEvent.hpp
+++ b/loader/include/Geode/ui/WindowResizeEvent.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "../loader/Event.hpp"
+
+namespace geode {
+    class WindowResizeEvent final : public Event<WindowResizeEvent, bool(const cocos2d::CCSize&)> {
+        using Event::Event;
+    };
+}

--- a/loader/src/hooks/WindowResize.cpp
+++ b/loader/src/hooks/WindowResize.cpp
@@ -1,0 +1,12 @@
+#include <Geode/ui/WindowResizeEvent.hpp>
+#include <Geode/modify/CCEGLViewProtocol.hpp>
+#include <cocos2d.h>
+
+using namespace geode::prelude;
+
+class $modify(CCEGLViewProtocol) {
+    void setFrameSize(float width, float height) override {
+        CCEGLViewProtocol::setFrameSize(width, height);
+        WindowResizeEvent().send(CCDirector::get()->getWinSize());
+    }
+};

--- a/loader/src/ui/nodes/OverlayManager.cpp
+++ b/loader/src/ui/nodes/OverlayManager.cpp
@@ -1,13 +1,26 @@
+#include "Geode/ui/WindowResizeEvent.hpp"
 #include <Geode/loader/ModEvent.hpp>
 #include <Geode/Loader.hpp>
 #include <Geode/ui/OverlayManager.hpp>
 
 using namespace geode::prelude;
 
+bool OverlayManager::init() {
+    if (!CCNode::init()) return false;
+    this->setContentSize(CCDirector::get()->getWinSize());
+    this->setLayout(AnchorLayout::create());
+    this->addEventListener(WindowResizeEvent(), [this](const CCSize& size){
+        setContentSize(size);
+        updateLayout();
+    }, 0);
+    return true;
+}
+
 OverlayManager* OverlayManager::get() {
     static OverlayManager* inst = nullptr;
     if (!inst) {
         inst = new OverlayManager();
+        inst->init();
         inst->onEnter();
     }
     return inst;


### PR DESCRIPTION
- Window resize event (idea by alpha)
- Make OverlayManager follow window size
- Add an anchor layout to OverlayManager (idea by cvolton)
  - this shouldn't break anything, anchor layout only affects nodes with anchorlayoutoptions and i don't think any current nodes added to overlaymanager have it