### PR TITLE
Fix Safe Areas not working on iOS

### DIFF
--- a/loader/src/hooks/FixSafeArea.cpp
+++ b/loader/src/hooks/FixSafeArea.cpp
@@ -1,0 +1,13 @@
+#ifdef GEODE_IS_IOS
+#include <Geode/Geode.hpp>
+#include <Geode/modify/AppDelegate.hpp>
+
+using namespace geode::prelude;
+
+class $modify(FixSafeAreaAppDelegate, AppDelegate) {
+    void setupGLView() {
+        AppDelegate::setupGLView();
+        m_needsSafeArea = geode::utils::getSafeAreaRect().size != CCDirector::get()->getWinSize();
+    }
+};
+#endif


### PR DESCRIPTION
This is a somewhat cheaty fix, but is needed due to how the Geode launcher on iOS handles resolution. 

By default GD's resolution is hard set at that of an iPhone 11 Pro for some reason. The width of that is 2436 on taller iPhones, and GD does this check.
<img width="339" height="21" alt="image" src="https://github.com/user-attachments/assets/9e111bb3-fe66-427a-a455-3cf867761605" />
This check fails in the launcher, due to the resolution being different and actually following the device (Funnily enough, this means this bug does not exist on iPhone 11 Pros using the Geode launcher). My solution is to merely set the bool needed to if the safe zone size geode provides is different than the window size.

Note that the node IDs mod does break some of these safe areas. Most actually work fine since detaching preserves position. But on ones that position is changed, it will likely still have an overlap. I will also be making a node IDs PR to accompany this one.