### PR TITLE
Draw the scrollbar on init to fix the content size

### DIFF
--- a/loader/src/ui/nodes/Scrollbar.cpp
+++ b/loader/src/ui/nodes/Scrollbar.cpp
@@ -200,6 +200,8 @@ bool Scrollbar::Impl::init(CCScrollLayerExt* target) {
     m_self->addChild(m_thumb);
 
     m_self->setTouchEnabled(true);
+    // Make sure the size is accurate in the first frame
+    m_self->draw();
 
     return true;
 }


### PR DESCRIPTION
Currently the scrollbar is a default size on creation making it hard to integrate it into a layout which expects the content size to already be correct.