### PR TITLE
Ambigious ctor

### DIFF
--- a/loader/include/Geode/cocos/cocoa/CCGeometry.h
+++ b/loader/include/Geode/cocos/cocoa/CCGeometry.h
@@ -325,10 +325,6 @@ public:
     /**
      * @lua NA
      */
-    inline constexpr CCSize(const CCPoint& point) : width(point.x), height(point.y) {}
-    /**
-     * @lua NA
-     */
     inline constexpr CCSize& operator= (const CCSize& other) {
         setSize(other.width, other.height);
         return *this;

--- a/loader/src/ui/nodes/Scrollbar.cpp
+++ b/loader/src/ui/nodes/Scrollbar.cpp
@@ -200,6 +200,8 @@ bool Scrollbar::Impl::init(CCScrollLayerExt* target) {
     m_self->addChild(m_thumb);
 
     m_self->setTouchEnabled(true);
+    // Make sure the size is accurate in the first frame
+    m_self->draw();
 
     return true;
 }


### PR DESCRIPTION
The main copy CTOR already allows CCPoint being used to construct CCSize, making it ambiguous to use when providing an initializer list (e.g. m_contentSize({ 0, 0 }))