### PR TITLE
fix fix safe areas on ipads

### DIFF
--- a/loader/src/hooks/FixSafeArea.cpp
+++ b/loader/src/hooks/FixSafeArea.cpp
@@ -9,7 +9,7 @@ class $modify(FixSafeAreaAppDelegate, AppDelegate) {
     void setupGLView() {
         AppDelegate::setupGLView();
         // just detect if the left inset exists (might be good to change to >= some value but i'm too lazy to see what that value is)
-        m_needsSafeArea = geode::utils::getSafeAreaRect().x > 0.0f;
+        m_needsSafeArea = geode::utils::getSafeAreaRect().origin.x > 0.0f;
     }
 };
 #endif

--- a/loader/src/hooks/FixSafeArea.cpp
+++ b/loader/src/hooks/FixSafeArea.cpp
@@ -8,7 +8,8 @@ using namespace geode::prelude;
 class $modify(FixSafeAreaAppDelegate, AppDelegate) {
     void setupGLView() {
         AppDelegate::setupGLView();
-        m_needsSafeArea = geode::utils::getSafeAreaRect().size != CCDirector::get()->getWinSize();
+        // just detect if the left inset exists (might be good to change to >= some value but i'm too lazy to see what that value is)
+        m_needsSafeArea = geode::utils::getSafeAreaRect().x > 0.0f;
     }
 };
 #endif


### PR DESCRIPTION
instead of detecting the presence of any insets, this detects if there is a left inset (which also counts for right as they're coded to be symmetrical). this prevents the code from triggering if content is vertically offset due to the home bar, which could be the case on ipads