### PR TITLE
remove duplicated flash CSS

### DIFF
--- a/flash.toml
+++ b/flash.toml
@@ -95,19 +95,3 @@ build-dir = "build-docs"
 # The file we use to get all the include paths and such
 infer-args-from = "loader/src/load.cpp"
 
-[[scripts.css]]
-name = "default.css"
-content = "docs/flash-template/default.css"
-
-[[scripts.css]]
-name = "nav.css"
-content = "docs/flash-template/nav.css"
-
-[[scripts.css]]
-name = "content.css"
-content = "docs/flash-template/content.css"
-
-[[scripts.css]]
-name = "themes.css"
-
-content = "docs/flash-template/themes.css"


### PR DESCRIPTION
Same as [the docs PR (geode-sdk/docs#119)](https://github.com/geode-sdk/docs/pull/119), removes overwritten CSS, keeping the version flash provides.